### PR TITLE
feat(site): build out full Astro site with content collections, layouts, and pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,22 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import mdx from '@astrojs/mdx';
+import sitemap from '@astrojs/sitemap';
+import expressiveCode from 'astro-expressive-code';
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  site: 'https://projectinsomnia.com',
+  integrations: [
+    expressiveCode({
+      themes: ['dracula'],
+    }),
+    mdx(),
+    sitemap(),
+  ],
+  markdown: {
+    shikiConfig: {
+      theme: 'dracula',
+    },
+  },
+});

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,16 @@
+import { defineCollection, z } from "astro:content";
+
+const postSchema = z.object({
+  title: z.string(),
+  date: z.coerce.date(),
+  description: z.string().optional(),
+  tags: z.array(z.string()).default([]),
+  mediumUrl: z.string().url().optional(),
+  draft: z.boolean().default(false),
+});
+
+export const collections = {
+  blog: defineCollection({ type: "content", schema: postSchema }),
+  ouatrevisit: defineCollection({ type: "content", schema: postSchema }),
+  elections: defineCollection({ type: "content", schema: postSchema }),
+};

--- a/src/content/blog/2016-08-07-athletic-self-assessment.md
+++ b/src/content/blog/2016-08-07-athletic-self-assessment.md
@@ -1,0 +1,19 @@
+---
+title: "Athletic self-assessment"
+date: 2016-08-07
+description: "Watching the Olympics brings to mind how I roughly approximate and rate my performance in any given athletic endeavor. I figure that if I’m…"
+tags: ["blog"]
+mediumUrl: "https://medium.com/@smartwatermelon/athletic-self-assessment-cf50cb99d4e5"
+---
+
+### Athletic self-assessment
+
+Watching the Olympics brings to mind how I roughly approximate and rate my performance in any given athletic endeavor. I figure that if I’m twice or half what a pro or elite does, then I’m doing pretty well.
+
+For example:
+
+Olympic swimmers do 100s in under a minute; my best are just over two.
+
+Elite half marathoners are an hour or so; I am right around two hours. Or another way, elite marathoners finish a bit over two hours, and I just yesterday broke two hours in the half.
+
+The best triathletes finish a 70.3 race in well under four hours and the full 140.6 in nine. I haven’t yet finished one of these (DNFed my first try at a 70.3) but have a goal of 7.5 hours for the 70.3 distance. Any thoughts of a full IRONMAN race are at least two years off, after I’ve completed quite a few more shorter distances.

--- a/src/content/blog/2016-08-09-good-news-comes-in-threes.md
+++ b/src/content/blog/2016-08-09-good-news-comes-in-threes.md
@@ -1,0 +1,19 @@
+---
+title: "Good News Comes In Threes"
+date: 2016-08-09
+description: "A huge personal athletic achievement: I broke two hours in the half marathon last weekend, at Brazen Racing’s Summer Breeze race in San…"
+tags: ["blog"]
+mediumUrl: "https://medium.com/@smartwatermelon/good-news-comes-in-threes-14d9d620b804"
+---
+
+### Good News Comes In Threes
+
+![Half marathon finish line celebration](https://cdn-images-1.medium.com/max/800/1*PsBPG9bpDrEVHGxknjs1ew.jpeg)
+
+A huge _personal athletic achievement_: I broke two hours in the half marathon last weekend, at Brazen Racing’s [Summer Breeze](http://brazenracing.com/r/summerbreeze.html) race in San Leandro, California. Very flat and very fast course, perfectly ideal weather ([Karl the Fog](https://medium.com/u/1f887b602064) in full effect). A sub-two hour half was a goal I’d only recently even started to consider seriously (I ran the [Capitola Half Marathon](http://www.surferspathmarathon.com/) in 2:03:21 back in May), so achieving it this summer was a terrific feeling. Next up: repeating this kind of finish at future speed-oriented races, like [Rock ’n’ Roll Philadelphia](http://www.runrocknroll.com/philadelphia/) in September.
+
+![Slack logo](https://cdn-images-1.medium.com/max/800/1*XAfCrBTr3MnHhv4mh70y2Q.png)
+
+A huge _professional opportunity_: I recently accepted an offer to join the engineering team at [Slack](https://medium.com/u/26d90a99f605) in the role of Senior Build and Release Engineer. I’m confident I will enjoy great success here, and I’ll begin this exciting next phase of my career on August 22nd.
+
+This is where I would write about the _third thing_, but I’m waiting to see what it will be. Stay tuned.

--- a/src/content/blog/2016-09-07-never-too-early.md
+++ b/src/content/blog/2016-09-07-never-too-early.md
@@ -1,0 +1,21 @@
+---
+title: "Never too early…"
+date: 2016-09-07
+description: "…to start thinking about my athletic goals for 2017."
+tags: ["blog"]
+mediumUrl: "https://medium.com/@smartwatermelon/never-too-early-661f8168adcf"
+---
+
+### Never too early…
+
+…to start thinking about my athletic goals for 2017.
+
+![Psychedelic marathon start line with runners](https://cdn-images-1.medium.com/max/800/1*z43H0qk3mJLY0xOZra6nRw.jpeg)
+*“Psychedelic Marathon Start” by [brewbooks](https://www.flickr.com/photos/brewbooks/) on Flickr*
+
+1. Miles in one event: I want to “run my age”, which will be 47. So 47 miles in one day… sounds like a perfect goal for Brazen Racing’s annual Dirty Dozen twelve-hour trail run. In 2016 I achieved my first “ultra” distance — 50K (actually 33.7 miles) at this event, over around nine hours. Running for twelve hours (including rest breaks) will be difficult, but I think I can do it.
+2. Speed goal: I want to run an “Ageless Wonder” 10K, that is, a 10K race in fewer minutes than my age. I’ll probably do that at another Brazen event, either the Bay Breeze or Summer Breeze; these are flat, fast races which are perfect for setting new personal speed goals.
+3. Race series goal: I plan to complete (at least) fifteen Rock ’n’ Roll events in 2017, which will earn me the Hall of Fame award. I’ll probably do at least one full marathon, and part of the goal will be racking up the series and combo medals.
+4. Triathlon goal: I’m looking for redemption after my DNF at 2016’s Ironman 70.3 Coeur d’Alene, and I’ll get it at the 2017 Ironman 70.3 Oceanside event. I’m well on my way to being ready for that; mostly concentrating on the swim and transitions.
+
+So, what do you have in the works for 2017?

--- a/src/content/blog/2017-03-16-syncing-garmin-forerunner-920xt-triathlon-activities-to-strava-and-runkeeper.md
+++ b/src/content/blog/2017-03-16-syncing-garmin-forerunner-920xt-triathlon-activities-to-strava-and-runkeeper.md
@@ -1,0 +1,34 @@
+---
+title: "Syncing Garmin Forerunner 920XT Triathlon activities to Strava and Runkeeper"
+date: 2017-03-16
+description: "The Garmin Forerunner 920XT is a terrific triathlon watch, and I really like the tri mode — where you just hit the Lap key in between…"
+tags: ["blog", "tech", "triathlon"]
+mediumUrl: "https://medium.com/@smartwatermelon/syncing-garmin-920xt-triathlon-activities-to-strava-and-runkeeper-a4d3ca34d344"
+---
+
+### Syncing Garmin Forerunner 920XT Triathlon activities to Strava and Runkeeper
+
+![Garmin Forerunner 920XT triathlon watch](https://cdn-images-1.medium.com/max/800/1*CXet_jzxO0WXdBx_4FEylg.png)
+*Garmin Forerunner 920XT (image courtesy Garmin)*
+
+The [Garmin Forerunner 920XT](https://buy.garmin.com/en-US/US/p/137024) is a terrific triathlon watch, and I really like the tri mode — where you just hit the *Lap* key in between segments (T1, run start, T2, bike start) and when you’re done, it creates a single “Triathlon” activity in [Garmin Connect](https://connect.garmin.com/en-US/).
+
+I use a Web service called [Tapiriik](https://tapiriik.com/) to automatically sync my workouts and races from Connect to [Strava](https://www.strava.com/) and [Runkeeper](https://runkeeper.com/home). Garmin actually has a built-in [Strava sync](https://support.strava.com/hc/en-us/articles/216918057-Uploading-from-a-Garmin-device-), but I find that it only works around half the time.
+
+Unfortunately, the other services don’t understand the Triathlon activity. Strava doesn’t have a multi-segment activity at all, and while Runkeeper does support an “Other” category, swims/bikes/runs recorded within an “Other” don’t actually show up within their respective category (which means they don’t count toward my annual goals!).
+
+So here’s how I resolve that problem, because tracking these individual segments is more important to me than recording the total time as a single activity. I should note that I have no connection to any company or service mentioned here, though I did receive my Forerunner 920XT as a contest prize in 2015.
+
+Step 1: Triathlon! Use the Forerunner 920XT’s Triathlon mode. Hit *Lap* in between segments. When you’re done (**congratulations!**), sync to Garmin Connect. I use the [Connect](https://itunes.apple.com/us/app/garmin-connect-mobile/id583446403?mt=8) app on my iPhone, but you could also do a wired sync to your computer.
+
+Step 2: Let Tapiriik and/or Garmin’s built-in Strava sync do their thing. Your triathlon activity will show up in Strava as five separate activities (swim, T1, bike, T2, run).
+
+Step 3: In your Strava dashboard, set the activity types for each segment. Strava doesn’t have “Swim to Bike” or “Bike to Run” so I use the generic “Workout” activity type for transitions. This is a good time to name the activity segments as well.
+
+Step 4: In your Strava dashboard, export each activity segment to GPX. (It’s under the wrench icon). This is where naming the activities comes in handy, because the GPX files will be downloaded using those names.
+
+Step 5: In Garmin Connect, import the five GPX files you just exported from Strava. You can use the bulk import mode to get them all at once, but you’ll need to adjust the name and activity type because that information isn’t saved with the GPX format. Garmin even has “swim to bike transition” and “bike to run transition” activity types. Once you’ve done this and have individual activities in Garmin Connect, you can delete the original multi-segment activity.
+
+Step 6 (optional): If you use Runkeeper, import the five GPX files and give them appropriate name and activity types. Runkeeper doesn’t have a “Transition” activity type, so I use “Other”.
+
+You’re done! And now, in Garmin Connect and Strava (and perhaps Runkeeper) you have the saved activity records for each segment of your huge triathlon achievement. You can look at your swim, your T1 time (my perennial weakness) and even the GPS tracks for your transitions — yup, those quick bathroom dashes show up — and the swim, bike, and run will count toward your defined goals if you have any.

--- a/src/content/blog/2017-11-07-an-incomplete-list-of-everything-reset-all-settings-actually-resets.md
+++ b/src/content/blog/2017-11-07-an-incomplete-list-of-everything-reset-all-settings-actually-resets.md
@@ -1,0 +1,39 @@
+---
+title: "An Incomplete List of Everything “Reset All Settings” Actually Resets"
+date: 2017-11-07
+description: "In troubleshooting a strange Apple Pay problem (the iPhone helpfully tells me to “Hold near reader to pay” even when the phone is literally…"
+tags: ["blog"]
+mediumUrl: "https://medium.com/@smartwatermelon/an-incomplete-list-of-everything-reset-all-settings-actually-resets-a92c29219dcd"
+---
+
+### An Incomplete List of Everything “Reset All Settings” Actually Resets
+
+In troubleshooting a strange Apple Pay problem (the iPhone helpfully tells me to “Hold near reader to pay” even when the phone is literally on top of the reader), the Apple Support rep suggested I do a “Reset All Settings”.
+
+Gulp.
+
+So I took a full iTunes backup, and …
+
+![iPhone Reset All Settings confirmation screen](https://cdn-images-1.medium.com/max/800/1*AAZqMABshT1RiMUj24_Sng.jpeg)
+*ALL of them*
+
+What follows is an incomplete list of everything I had to reconfigure after the iPhone finished resetting and came back up.
+
+- Wifi networks
+- Touch ID fingerprints
+- Notification settings for many apps; some apps need to be deleted and reinstalled to recover notification access
+- Location settings for all apps
+- Text size and display zoom settings
+- Wallpapers and Lock Screen images
+- Third-party keyboard access (e.g. Gboard, Bitmoji)
+- Credit cards stored in Apple Pay (cached, but need to be reactivated by typing in the three- or four-digit security code on each card)
+- Notification Center controls
+- iCloud Messages syncing from iPhone to and from Mac
+- Raise to Wake
+- Alarms and Bedtime settings
+
+And I’m not sure yet whether this Reset All Settings actually fixed the Apple Pay problem, because the only way to test is to actually try an Apple Pay transaction. So I’ll do that when I can, and update the post at that point.
+
+**Update: It didn’t.**
+
+I totally forgot to update this post. Reset All Settings did not fix the Apple Pay problem, and neither did a full Reset, so I exchanged the phone at the Apple Store and now all is well. Strangely, the phone did pass the hardware test administered by the tech at the Apple Store. So I really have no idea why Apple Pay stopped working.

--- a/src/content/blog/2018-05-14-hallway.md
+++ b/src/content/blog/2018-05-14-hallway.md
@@ -1,0 +1,27 @@
+---
+title: "Hallway"
+date: 2018-05-14
+description: "I wrote this for a Narration class last weekend, based on an extemporaneous speech about “my favorite room”; the homework assignment was to…"
+tags: ["blog"]
+mediumUrl: "https://medium.com/@smartwatermelon/hallway-9a63f5df4ba3"
+---
+
+### Hallway
+
+_I wrote this for a Narration class last weekend, based on an extemporaneous speech about “my favorite room”; the homework assignment was to expand and clean-up the speech, without listening to the recording! We were surprised in the next session when our submissions were shuffled and given to other classmates. After hearing a classmate read this, I thought it would make a good post._
+
+__Listen to this post on Soundcloud__
+
+I dithered a bit about what to write; my house is fairly nondescript. A stock 1980 vaguely Spanish-style California townhome, like a million others. Quite a bit of work since buying in 2002, new kitchen, floors, and the like. But there isn’t a lot of me in any particular room.
+
+Except for the upstairs hallway.
+
+The upstairs hallway runs from the stairs to the master bedroom, guest bath, and guest bedroom. It’s four feet wide by around twelve feet long. Oak floors, taupe walls.
+
+On one side, constructed a set of shallow floor-to-ceiling bookshelves out of a discontinued IKEA media cabinet. It’s loaded with my collection of paperbacks, mostly science-fiction novels and anthologies, which I’ve been collecting more or less nonstop since my teens. There are several hundred, in roughly alphabetical order by author.
+
+On the other side, my race medals. Since I began running races in 2012, I’ve finished 73 half and seven full marathons; two IRONMAN 70.3 triathlons; endurance trail runs; and countless shorter races. There are literally hundreds of medals, mounted to the wall by means of another IKEA hack — this time, a shallow kitchen rail system.
+
+This hallway says a lot about me. On one side, the bookish sci-fi nerd (a title I wear proudly); on the other, the endurance athlete and collector of bling. As I walk past, I can stop and point at any random book or medal and instantly remember an important moment from my past.
+
+And that’s why it’s my favorite room in the house, thought it be not a room at all.

--- a/src/content/blog/2020-04-18-how-to-get-your-peloton-rides-into-ironman-vr-club.md
+++ b/src/content/blog/2020-04-18-how-to-get-your-peloton-rides-into-ironman-vr-club.md
@@ -1,0 +1,64 @@
+---
+title: "HOW TO GET YOUR PELOTON RIDES INTO IRONMAN VR CLUB"
+date: 2020-04-18
+description: "SportHeroes’ application security failures impact IRONMAN VR Club participants"
+tags: ["blog", "tech", "triathlon"]
+mediumUrl: "https://medium.com/@smartwatermelon/how-to-get-your-peloton-rides-into-ironman-vr-club-b344511b6f62"
+---
+
+### How to get your Peloton rides into IRONMAN VR Club
+
+#### SportHeroes’ application security failures impact IRONMAN VR Club participants
+
+**Update 2020–04–27:** SportHeroes have fixed a separate issue with their FitBit integration. If you have or want to create a FitBit account (you don’t need a FitBit device to create an account), you can share your Peloton rides to FitBit and link it to SportHeroes. This allows your Peloton rides to show up immediately in the IRONMAN VR Club dashboard with no exporting or editing needed!
+
+Thanks to Paul-Emile at SportHeroes for reaching out personally about this issue.
+
+**Update 2020–04–21:** I’ve narrowed down the specific incompatibility between activities originating on Peloton and auto-synced to Strava which prevents them from successfully importing to Garmin Connect.
+
+1. Complete your Peloton ride and auto-sync it to Strava.
+2. On your computer, export the Strava activity to TCX. Open the TCX in an editor like Notepad or TextEdit. Look for this section:  
+
+```
+    `<Creator><Name>PELOTON</Name></Creator>`
+3.  Change it to:  
+     `<Creator xsi:type=”Device_t”>    <Name>Garmin Forerunner 920XT</Name>    <UnitId>12345678</UnitId>    <ProductID>1765</ProductID>    <Version>    <VersionMajor>1</VersionMajor>    <VersionMinor>1</VersionMinor>    <BuildMajor>1</BuildMajor>    <BuildMinor>1</BuildMinor>    </Version>    </Creator>`
+4.  Save the TCX file. You don’t need to run it through GOTOES. You should now be able to import it into Garmin Connect, and SportHeroes should automatically pick it up and credit your ride.
+```
+
+**Note:** You can try other Garmin device types besides `Forerunner 920XT`. That’s the device I have, so it’s the one I used here. Your results may vary.
+
+I’m not going to rehash the whole [Strava vs. SportHeroes tiff](https://www.dcrainmaker.com/2020/04/strava-cuts-off-ironman-virtual-club-an-explainer-to-sports-tech-drama.html). It’s boring, and it doesn’t matter to us, the athletes (just like when cable companies and TV networks fight: the only one who loses is the consumer).
+
+What I _am_ going to do is present a method you can use to get your Peloton rides out of Strava and into the IRONMAN VR Club platform (operated by SportHeroes) in a way that lets the activities count. No more “manual additions” errors!
+
+Here’s what you need:  
+1\. Strava account connected to Peloton account, so Peloton rides are automatically sent to Strava. You probably had this already.  
+2\. Garmin Connect account connected to IRONMAN VR Club account: go to [https://app.ironmanvirtualclub.com/en/dashboard](https://app.ironmanvirtualclub.com/en/dashboard) and click “Manage my Apps”, then add Garmin Connect. Make sure you do this **before** continuing below.
+
+Here’s how to do it:  
+1\. Ride the required distance on the Peloton. I like the “Just Ride” option while watching classic hockey or baseball.  
+2\. **On your computer,** go to [https://www.strava.com/athlete/training](https://www.strava.com/athlete/training) and find the Peloton ride you just completed.  
+3\. Click the name of the ride (e.g. “30 minute Just Ride”). In the activity’s detail screen, click the three-dot menu and select “Export Original”.
+This will download a TCX file with the same name as your ride.  
+
+```
+4. Go to [https://gotoes.org/strava/Combine_GPX_TCX_FIT_Files.php](https://gotoes.org/strava/Combine_GPX_TCX_FIT_Files.php) and upload the TCX file you just downloaded. Once you’ve uploaded the file, click the “Click Here” link to go to the download page.  
+5. Use the **following options** on the download page:   
+• TCX format   
+• GPS Type (select your Garmin device if you have one, or pick one; **don’t select PELOTON**)   
+• Activity Type: Biking   
+• Use Existing Embedded Distance   
+• Do Not Discard Track Points   
+Then click the big blue “Combine GPS Files” button.   
+This will download a new TCX file with a long series of digits in the name. You can rename it if you want.  
+6. Go to [https://connect.garmin.com/modern/import-data](https://connect.garmin.com/modern/import-data) and upload the **new TCX file** you just downloaded from GOTOES. Click the blue “Import Data” button, and when it’s done, the “View Details” link.   
+This will take you to the details of the activity you just uploaded. Verify it looks correct, i.e. distance and time.   
+You can rename the activity from the default “Cycling” in Garmin Connect if you want.  
+7. Go back to your IRONMAN VR Club dashboard [https://app.ironmanvirtualclub.com/en/dashboard](https://app.ironmanvirtualclub.com/en/dashboard) and click the green “Refresh” button.   
+**Your ride should show up as an accepted activity.** The activity should show as imported from Garmin.
+```
+
+**This worked for me.** I don’t guarantee it will work for you, and it may stop working at any time. **Don’t use this technique or these tools to cheat.** This just gets us past a difficult situation; hopefully, IRONMAN and Strava work out their differences sooner rather than later. **I am not associated with IRONMAN, Strava, Garmin, or GOTOES.**
+
+If it worked for you, consider tipping the folks at [GOTOES](https://gotoes.org/), without whose tools the exported Peloton/Strava file would not be importable into Garmin and thus accepted by the SportHeroes platform.

--- a/src/content/blog/2021-03-11-how-to-build-a-great-company-culture.md
+++ b/src/content/blog/2021-03-11-how-to-build-a-great-company-culture.md
@@ -1,0 +1,32 @@
+---
+title: "How to build a great company culture!"
+date: 2021-03-11
+description: "Want to build a great company culture? Here are your four essential components."
+tags: ["blog", "satire", "work"]
+mediumUrl: "https://medium.com/@smartwatermelon/how-to-build-a-great-company-culture-5ca3aeabbf4b"
+---
+
+### How to build a great company culture
+
+Want to build a great company culture? Here are your four essential components.
+
+![Open source company culture illustration](https://cdn-images-1.medium.com/max/800/1*h1UXF9dPpYN8WQm68MrAgQ.jpeg)
+*Flickr user opensourceway [https://flic.kr/p/8S4XtH](https://flic.kr/p/8S4XtH) CC BY-SA 2.0*
+
+1. Tell us what you want us to work on. Be as specific as you reasonably can, given our level and responsibilities. Don't vaguely gesture at, "you know, try to find things to work on that will support our mission," and then chastise us for not finding the thing you were thinking of but didn't tell us.
+
+    *Can't do that? Bad culture!*
+
+2. Give us access to the people and resources we need to do the work. Make it clear and easy to find the domain experts and the documentation. Don't have progress or knowledge gated behind people who don't respond to questions or document their knowledge.
+
+    *Can't do that? Bad culture!*
+
+3. Acknowledge, publicly, the accomplishments and hard work we're putting in. If there's a defined system for atta-boys, use it. Encourage a habit of people high-fiving each other for getting stuff done and solving problems. Don't simply assume we're happily trucking along doing our work with no particular acknowledgment. Especially don't atta-boy the same five people every week. Trust me, it's noticed.
+
+    *Can't do that? Bad culture!*
+
+4. Pay us fairly, based on the standards and trends in our industry. Life costs money. We work for you for money. We don't work for you for fun.
+
+    *Can't do that? Bad culture (and a lot of trouble keeping employees, too)!*
+
+5. **Bonus!** Use the money you saved not doing bullshit "culture surveys" for employee perks.

--- a/src/content/blog/2023-01-01-my-2022-in-live-music.md
+++ b/src/content/blog/2023-01-01-my-2022-in-live-music.md
@@ -1,0 +1,122 @@
+---
+title: "My 2022 in live music"
+date: 2023-01-01
+description: "My setlist.fm stats tell the story: I love live music. And after a dreary nearly three years of pandemic cancellations, live music is back…"
+tags: ["blog", "music"]
+mediumUrl: "https://medium.com/@smartwatermelon/my-2022-in-live-music-cf89ad977165"
+---
+
+### My 2022 in live music
+
+My [setlist.fm](https://www.setlist.fm/user/smartwatermelon) stats tell the story: I love live music. And after a dreary nearly three years of pandemic cancellations, live music is back! In 2022, I went to seven live shows and saw 14 artists. Before that, it had been since late 2019!
+
+_(edit: as you can see from setlist, I forgot about the December 2021 Straight No Chaser show in San Jose!)_
+
+During this interregnum, mainly _after_ buying tickets to shows that were postponed due to the pandemic, we moved from the Bay Area to Spokane, Washington. Attending most of these shows meant flying back to Northern California for a day or two or six.
+
+#### The B-52s with The Tubes
+
+August 22, McCaw Hall, Seattle
+
+A quick one-night trip to Seattle for the B-52s' “Final Tour Ever of Planet Earth,” with opener and classic-alternative staple The Tubes.
+
+![The Tubes opening for The B-52s at McCaw Hall Seattle](https://cdn-images-1.medium.com/max/800/1*b9jK4xve285zQJpuNyQvSg.jpeg)
+_The Tubes opening for The B-52s at McCaw Hall, Seattle, August 22, 2022 / Andrew Rich_
+
+![The B-52s at McCaw Hall Seattle](https://cdn-images-1.medium.com/max/800/1*IfkgeEGYKCdf5x6jzD7_Xw.jpeg)
+_The B-52s at McCaw Hall, Seattle, August 22, 2022 / Andrew Rich_
+
+#### Lady Gaga: The Chromatica Ball
+
+September 8, Oracle Park, San Francisco
+
+This was the first of three trips to the Bay Area within four weeks to see five shows with a total of ten bands! To be fair, most of these had been planned pre-pandemic—well before the move to Spokane—and had coincidentally all been rescheduled close to each other.
+
+![The stage set for the Chromatica Ball at Oracle Park](https://cdn-images-1.medium.com/max/800/1*XMTjoAS1v_0LrrFg1Hy1fg.jpeg)
+_The stage is set for the Chromatica Ball at Oracle Park, September 8, 2022 / Andrew Rich_
+
+![Lady Gaga performing at the Chromatica Ball at Oracle Park](https://cdn-images-1.medium.com/max/800/1*iE583jCMsSnDeDVOoeVxqQ.jpeg)
+_Lady Gaga: The Chromatica Ball at Oracle Park, September 8, 2022 / Andrew Rich_
+
+#### Roxy Music with St. Vincent
+
+September 26, Chase Center, San Francisco
+
+This was Roxy Music’s 50th Anniversary Tour, and though they didn’t specifically announce it, it was likely their farewell tour. It was also Bryan Ferry’s 77th birthday!
+
+![Roxy Music at Chase Center San Francisco](https://cdn-images-1.medium.com/max/800/1*0Dn0LUCcxpo7BsUH8xMYTw.jpeg)
+_Roxy Music at Chase Center, September 26, 2022 / Andrew Rich_
+
+This next batch of three shows took place over one epic seven-day trip! We didn’t plan it that way, of course — the New Order/Pet Shop Boys had already been rescheduled twice — but it worked out well. I also ran my 111th half marathon while we were in the Bay Area (but that’s another post).
+
+#### Metric with Secret Machines
+
+October 7, The Fillmore, San Francisco
+
+Metric announced the 2022 Doomscroller tour while we were on a ship, and I had to use touchy shipboard Internet to buy tickets. But there was no chance I would miss seeing my favorite band perform for the first time since March 2019.
+
+![Secret Machines opening for Metric at The Fillmore](https://cdn-images-1.medium.com/max/800/1*Wvr_ZDdr9Z7o_D_zt-41BQ.jpeg)
+_Secret Machines opening for Metric at The Fillmore, October 7, 2022 / Andrew Rich_
+
+![Metric at The Fillmore San Francisco](https://cdn-images-1.medium.com/max/800/1*JcMS1XXqshAIIlnT3Q6T1g.jpeg)
+_Metric at The Fillmore, October 7, 2022 / Andrew Rich_
+
+![Metric performing at The Fillmore San Francisco](https://cdn-images-1.medium.com/max/800/1*nQuinWgBgOQMamgspJKxOQ.jpeg)
+_Metric at The Fillmore, October 7, 2022 / Andrew Rich_
+
+#### Florence + The Machine with Wet Leg
+
+October 9, Shoreline Amphitheatre, Mountain View
+
+![Wet Leg opening for Florence and The Machine at Shoreline Amphitheatre](https://cdn-images-1.medium.com/max/800/1*8h5sWaD2HQiDyJlEKT91Xg.jpeg)
+_Wet Leg opening for Florence + The Machine at Shoreline Amphitheatre, October 9, 2022 / Andrew Rich_
+
+_Wet Leg performing “Chaise Lounge” at Shoreline Amphitheatre, October 9, 2022 / Andrew Rich_
+
+![Florence Welch of Florence and The Machine at Shoreline Amphitheatre](https://cdn-images-1.medium.com/max/800/1*sAnYYvrSMB9pNIAh4zTL8Q.jpeg)
+_Florence Welch of Florence + The Machine at Shoreline Amphitheatre, October 9, 2022 / Andrew Rich_
+
+#### New Order / Pet Shop Boys with Paul Oakenfold: The Unity Tour
+
+October 12, Chase Center, San Francisco
+
+We were back at Chase Center just two weeks after Roxy Music to see this epic dual-headliner show, which was originally scheduled for October 2020 — we bought the tickets in October 2019! — and postponed first to 2021 and then finally to 2022.
+
+![Paul Oakenfold opening for New Order and Pet Shop Boys at Chase Center](https://cdn-images-1.medium.com/max/800/1*N4Wb0aHE4J2Pq02NrBc21Q.jpeg)
+_Paul Oakenfold opening for New Order and Pet Shop Boys at Chase Center, October 12, 2022 / Andrew Rich_
+
+![Group photo at Chase Center for New Order and Pet Shop Boys show](https://cdn-images-1.medium.com/max/800/1*UrCQyDVwrShUZnxO6_tNYA.jpeg)
+_(from left) Me, Jen, Joe, David at Chase Center, October 12, 2022 / David R. Perry_
+
+![New Order at Chase Center San Francisco](https://cdn-images-1.medium.com/max/800/1*AwSFPnKWNPaoZ2ePYG9z_g.jpeg)
+_New Order at Chase Center, October 12, 2022 / Andrew Rich_
+
+![Pet Shop Boys at Chase Center San Francisco](https://cdn-images-1.medium.com/max/800/1*8eg5gwYhL6dDo8Ir_CmZNw.jpeg)
+_Pet Shop Boys at Chase Center, October 12, 2022 / Andrew Rich_
+
+#### Phantogram with GLU
+
+November 12, Knitting Factory, Spokane
+
+Our first show in our new hometown!
+
+![GLU opening for Phantogram at Knitting Factory Spokane](https://cdn-images-1.medium.com/max/800/1*zYSmLSLex7q8va2BVgraFA.jpeg)
+_GLU opening for Phantogram at Knitting Factory, Spokane, November 12, 2022 / Andrew Rich_
+
+![Phantogram at Knitting Factory Spokane](https://cdn-images-1.medium.com/max/800/1*r6ZkGJhSuV_f4Ac7i7tBAA.jpeg)
+_Phantogram at Knitting Factory, Spokane, November 12, 2022 / Andrew Rich_
+
+![Phantogram performing at Knitting Factory Spokane](https://cdn-images-1.medium.com/max/800/1*n1vdbEqgRBC-Qvx_H3FkHQ.jpeg)
+_Phantogram at Knitting Factory, Spokane, November 12, 2022 / Andrew Rich_
+
+Thanks for following along as I recapped a fantastic year (well, three months) of live music. Coming up in 2023, I plan to see:
+
+- Depeche Mode (Las Vegas, March 30)
+- They Might Be Giants (Oakland, April 16)
+- Crowded House (Seattle, May 3)
+- Taylor Swift (Seattle, July 22)
+- Paramore (Seattle, July 24)
+
+I’ll also be looking out for great shows here in Spokane.
+
+You can find me on [Instagram](https://www.instagram.com/smartwatermelon/) and [Mastodon](https://worldkey.io/@smartwatermelon). Happy New Year!

--- a/src/content/blog/2023-05-12-how-to-corporate.md
+++ b/src/content/blog/2023-05-12-how-to-corporate.md
@@ -1,0 +1,22 @@
+---
+title: "how to corporate"
+date: 2023-05-12
+description: "put the bad news on blue slides, because blue = calming"
+tags: ["blog", "satire", "work"]
+mediumUrl: "https://medium.com/@smartwatermelon/how-to-corporate-852e64e07afe"
+---
+
+### how to corporate
+
+- put the bad news on blue slides, because blue = calming
+- roll out the female executives, because female voice reminds them of mom and mom would never hurt them
+- buzzword, buzzword, buzzword! they can’t complain about what they don’t understand
+- use the passive voice: “if you should find yourself in the position of being part of a restructuring”
+- make clever jokes amongst ourselves because, ha-ha, we’re safe!
+- oops, apologize for the jokes, but then make another one, it’s just so funny!
+- euphemize, euphemize, euphemize: “positional change”, “rotate in a different direction”, “re-evaluate your future”
+- one more joke for good measure
+- end on a high note and tell them you look forward to seeing them again at the next all-hands, except for the ones who get cut before then, ha-ha!
+
+![Empty corporate conference room with chairs](https://cdn-images-1.medium.com/max/800/1*iVvCNI08x3kSCWdG9M9L3A.jpeg)
+*Photo by [Pawel Chu](https://unsplash.com/@pawell?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/photos/ULh0i2txBCY?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)*

--- a/src/content/blog/2023-12-23-how-to-remove-unwanted-items-from-plexs-recently-added-sections.md
+++ b/src/content/blog/2023-12-23-how-to-remove-unwanted-items-from-plexs-recently-added-sections.md
@@ -1,0 +1,62 @@
+---
+title: "How to remove unwanted items from Plex’s “Recently Added” sections"
+date: 2023-12-23
+description: "I added a movie in 2019 but it’s showing as Recently Added. Annoying!"
+tags: ["blog", "tech"]
+mediumUrl: "https://medium.com/@smartwatermelon/how-to-remove-unwanted-items-from-plexs-recently-added-sections-a1bc7f34083f"
+---
+
+### How to remove unwanted items from Plex’s “Recently Added” sections
+
+There’s a lot of conflicting and outdated information on this topic. With my typical combination of hyperfocus, trial-and-error, and a lot of swearing, I’ve worked out the current procedure _(December 2023, PMS version 1.40.0.7775, macOS, YMMV)_.
+
+![Person frustrated at a computer screen](https://cdn-images-1.medium.com/max/800/1*yzzDK3H9FP9r5YI_ZsbbBw.jpeg)
+_Photo by [Sigmund](https://unsplash.com/@sigmund?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash) on [Unsplash](https://unsplash.com/photos/woman-in-black-shirt-sitting-beside-black-flat-screen-computer-monitor-Im_cQ6hQo10?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash)_
+
+#### Why do I need this?
+
+You need this if your Plex dashboard’s “Recently Added Movies” (or TV Shows) section suddenly shows items you added months or years ago. PMS doesn’t offer a way to flag an item as “not recently added” or “don’t show this in the Recently Added section.”
+
+#### Do I need to be an expert hacker?
+
+You need to be comfortable with the macOS Terminal. I’ll give you some copy-and-paste commands to use, but just be aware this is not for the beginner.
+
+#### Will you fix my Plex and/or Mac if I break it?
+
+No.
+
+1. Stop PMS. Click and hold the Plex icon in the Mac's Dock and select Quit.
+2. Back up your database and settings. [Here is guidance from Plex](https://support.plex.tv/articles/201539237-backing-up-plex-media-server-data/) on how to do this. In current versions of PMS on macOS, the database is at:  
+
+```
+    `/System/Volumes/Data/Users/$USER/Library/Application Support/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.db`
+3.  Launch Terminal and open the Plex database in Plex’s custom SQLite3:  
+    `$ /Applications/Plex\ Media\ Server.app/Contents/MacOS/Plex\ SQLite “/System/Volumes/Data/Users/$USER/Library/Application Support/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.db”`
+4.  Find the offending item (substitute a word in the title for TITLE here):  
+    `sqlite> select title from metadata_items where title like ‘%TITLE%’;`
+5.  You’ll see a response showing the title(s) matching your query. Look at the `added_at` timestamp to confirm this is the issue. It should show something much more recent than when the item was actually added, possibly even a future date/time.  
+    `sqlite> select datetime(added_at, ‘unixepoch’, ‘localtime’) from metadata_items where title like ‘%TITLE%’;`
+6.  Figure out what timestamp you want the item(s) to have. For mine, I just wanted the `added_at` timestamp to be the same as the file date (i.e., when I acquired the file and added it to Plex in the first place). You can use [EpochConverter](https://www.epochconverter.com/) for this. For example, January 20, 2021, at noon EST, is `1611162000` in Unix Epoch time.
+7.  Fix the `added_at` timestamp on the problem item(s).  
+    *** WARNING: THIS WRITES TO YOUR PLEX DATABASE. IF YOU TYPO IT, OR THERE’S A NETWORK INTERRUPTION WHILE THE CHANGE IS BEING WRITTEN, OR YOUR CAT JUMPS ON THE KEYBOARD AT THE WRONG SECOND, THERE COULD BE BAD CONSEQUENCES. DID YOU BACK UP YOUR DATABASE? ***  
+    `sqlite> update metadata_items set added_at = ‘TIMESTAMP’ where title like ‘%TITLE%’;`
+8.  Double-check that the `added_at` timestamp is now correct:  
+    `sqlite> select datetime(added_at, ‘unixepoch’, ‘localtime’) from metadata_items where title like ‘%TITLE%’;`
+9.  Exit SQLite3 with `.quit`, and launch Plex. You should re-scan the Movies library. Check the “Recently Added” section. The item(s) you fixed should no longer be present.
+```
+
+Good luck! Feel free to comment about whether this helped. Again, though, I can’t offer technical support. Make sure to back up your database!
+
+Sources:
+
+```
+-   [https://www.reddit.com/r/PleX/comments/ml98am/how_do_i_fix_recently_added_being_stuck_due_to/](https://www.reddit.com/r/PleX/comments/ml98am/how_do_i_fix_recently_added_being_stuck_due_to/)
+-   [https://web.archive.org/web/20230208003624/https://getsysadminblog.com/2019/09/30/plex-fix-stuck-items-in-the-recently-added-dashboards/](https://web.archive.org/web/20230208003624/https://getsysadminblog.com/2019/09/30/plex-fix-stuck-items-in-the-recently-added-dashboards/)
+-   [https://michielvanerp.wordpress.com/2021/08/22/plex-fix-recently-added/](https://michielvanerp.wordpress.com/2021/08/22/plex-fix-recently-added/)
+-   [https://support.plex.tv/articles/202915258-where-is-the-plex-media-server-data-directory-located/](https://support.plex.tv/articles/202915258-where-is-the-plex-media-server-data-directory-located/)
+-   [https://www.epochconverter.com/](https://www.epochconverter.com/)
+-   [https://support.plex.tv/articles/201539237-backing-up-plex-media-server-data/](https://support.plex.tv/articles/201539237-backing-up-plex-media-server-data/)
+```
+
+![Cat sitting next to a laptop computer](https://cdn-images-1.medium.com/max/800/1*QR34Iq_tJAZOZ-rZCpgiWA.jpeg)
+_Photo by [Dillon Kydd](https://unsplash.com/@kyddvisuals?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash) on [Unsplash](https://unsplash.com/photos/a-cat-sitting-on-top-of-a-desk-next-to-a-laptop-computer-9XrdePyTewE?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash)_

--- a/src/content/blog/2024-03-07-my-2023-in-live-music.md
+++ b/src/content/blog/2024-03-07-my-2023-in-live-music.md
@@ -1,0 +1,184 @@
+---
+title: "My 2023 in live music"
+date: 2024-03-07
+description: "It's a bit late, but here is my 2023 live music wrap-up!"
+tags: ["blog", "music"]
+mediumUrl: "https://medium.com/@smartwatermelon/my-2023-in-live-music-8e83b84ba899"
+---
+
+### My 2023 in live music
+
+It's a bit late, but here is my 2023 live music wrap-up! ([2022’s wrap is here](https://medium.com/@smartwatermelon/my-2022-in-live-music-cf89ad977165).)
+
+In 2023, we attended [nine live shows](https://www.setlist.fm/user/smartwatermelon), including our final pandemic-postponed concert (They Might Be Giants). Family health issues forced us to miss three planned events (Crowded House, Taylor Swift, and Paramore), but we still had a great year.
+
+#### Colin Mochrie & Brad Sherwood: Scared Scriptless
+
+January 13, The Martin Woldson Theater at The Fox, Spokane
+
+Colin and Brad from “Whose Line Is It Anyway” have been teaming up for versions of this live show for years; we first saw them in 2006 in San Jose.
+
+![Colin Mochrie and Brad Sherwood Scared Scriptless at The Fox Spokane](https://cdn-images-1.medium.com/max/800/1*4w7gd-_rQlcCMzIkiySnzw.jpeg)
+*Colin Mochrie & Brad Sherwood: Scared Scriptless  
+January 13, 2023, The Martin Woldson Theater at The Fox, Spokane / Andrew Rich*
+
+#### The Bacon Brothers
+
+January 27, Pend Oreille Pavilion, Airway Heights, WA
+
+The Bacon Brothers are actor/singer Kevin Bacon and his brother, composer Michael Bacon. They put on a rocking good show and ended with a familiar cover.
+
+![The Bacon Brothers at Pend Oreille Pavilion](https://cdn-images-1.medium.com/max/800/1*WF834AKdL4TyQE85TIU9Rw.jpeg)
+*The Bacon Brothers at Pend Oreille Pavilion, Airway Heights, WA, Jan 27, 2023 / Andrew Rich*
+
+#### Alvvays w/Disq
+
+March 13, The Knitting Factory, Spokane
+
+I found a new favorite band in Alvvays when they visited Spokane last March. And they just announced they’d be back this August! We’ll be there. Molly Rankin, the group’s singer-songwriter, said, “Monday night in Spokane is better than Friday night in a lot of places we’ve played.”
+
+![Alvvays at The Knitting Factory Spokane](https://cdn-images-1.medium.com/max/800/1*jsqG3bJFfBYzfhrcx0tbvg.jpeg)
+*Alvvays  
+March 13, 2023, The Knitting Factory, Spokane / Andrew Rich*
+
+#### Depeche Mode w/Kelly Lee Owens
+
+March 30, T-Mobile Arena, Las Vegas
+
+This was my fifth time seeing Depeche Mode, dating back to the 1988 Concert for the Masses at the Rose Bowl. Kelly Lee Owens, a Welsh electronic musician, did a terrific opening set.
+
+![Depeche Mode at T-Mobile Arena Las Vegas](https://cdn-images-1.medium.com/max/800/1*suJ95P6XRF2qR2wS7iXg1A.jpeg)
+*Depeche Mode  
+March 30, 2023, T-Mobile Arena, Las Vegas / Andrew Rich*
+
+![Depeche Mode performing at T-Mobile Arena Las Vegas](https://cdn-images-1.medium.com/max/800/1*XglFaONx9P4YUdplLUw4Xw.jpeg)
+*Depeche Mode  
+March 30, 2023, T-Mobile Arena, Las Vegas / Andrew Rich*
+
+#### They Might Be Giants
+
+April 16, Fox Theatre, Oakland, CA
+
+We bought these tickets on February 27, 2020, for a show scheduled for October 9. It was postponed a few times and eventually finally went on last April. TMBG played the entirety of their 1990 album “Flood,” along with plenty of other hits and rarities.
+
+![They Might Be Giants at Fox Theatre Oakland](https://cdn-images-1.medium.com/max/800/1*ml2r1S8FA0Vku_bcIKxpFA.jpeg)
+*They Might Be Giants  
+April 16, 2023, Fox Theatre, Oakland, CA / Andrew Rich*
+
+#### Cruel World Festival
+
+May 20, Brookside at the Rose Bowl, Pasadena
+
+Bands we saw at this sprawling festival included Animotion, Berlin, ABC, Gang of Four, The Vapors, Modern English, Echo & The Bunnymen, Love and Rockets (in their first live show since 2008), and Iggy Pop (in an abbreviated set). Simultaneous set times meant we missed The Human League and Billy Idol (though, see below for Billy), and excessively twitchy show producers pulled the plug on the festival due to reports of adverse weather before the headliner, Siouxsie Sioux, could perform. Iggy and Siouxsie returned for sets the following evening, but we had already left town.
+
+![Animotion at Cruel World Festival Pasadena](https://cdn-images-1.medium.com/max/800/1*36a2Xpta4zhIHT__cYnXPg.jpeg)
+*Animotion at Cruel World Festival  
+May 20, 2023, Brookside at the Rose Bowl, Pasadena / Andrew Rich*
+
+![Richard Blade at Cruel World Festival Pasadena](https://cdn-images-1.medium.com/max/800/1*7ioKoDV-4SqAgw4LqakHTA.jpeg)
+*Los Angeles DJ and alternative music icon Richard Blade at Cruel World Festival  
+May 20, 2023, Brookside at the Rose Bowl, Pasadena / Andrew Rich*
+
+![Terri Nunn of Berlin singing among the crowd at Cruel World Festival](https://cdn-images-1.medium.com/max/800/1*SMJEitAMIEZB7WUEdR9yBA.jpeg)
+*Terri Nunn of Berlin singing among the crowd at Cruel World Festival  
+May 20, 2023, Brookside at the Rose Bowl, Pasadena / Andrew Rich*
+
+![ABC at Cruel World Festival Pasadena](https://cdn-images-1.medium.com/max/800/1*rdequ56USyUBuousbOUdvg.jpeg)
+*ABC at Cruel World Festival  
+May 20, 2023, Brookside at the Rose Bowl, Pasadena / Andrew Rich*
+
+![Echo and The Bunnymen at Cruel World Festival Pasadena](https://cdn-images-1.medium.com/max/800/1*7PSA6IggMxYyGr-GPFM4GA.jpeg)
+*Echo & The Bunnymen at Cruel World Festival  
+May 20, 2023, Brookside at the Rose Bowl, Pasadena / Andrew Rich*
+
+![Love and Rockets at Cruel World Festival Pasadena](https://cdn-images-1.medium.com/max/800/1*-dNFi6o0fJWTa1PlV8_Auw.jpeg)
+*Love and Rockets at Cruel World Festival  
+May 20, 2023, Brookside at the Rose Bowl, Pasadena / Andrew Rich*
+
+![Iggy Pop at Cruel World Festival Pasadena](https://cdn-images-1.medium.com/max/800/1*lz6Ate0aEYk0wiGioMIdYA.jpeg)
+*Iggy Pop at Cruel World Festival  
+May 20, 2023, Brookside at the Rose Bowl, Pasadena / Andrew Rich*
+
+![Clear sky at Cruel World Festival despite premature shutdown](https://cdn-images-1.medium.com/max/800/1*lEyTRWZ3mqMGnsyUkjkG7g.jpeg)
+*There was no inclement weather at the Cruel World Festival, but they pulled the plug anyway.  
+May 20, 2023, Brookside at the Rose Bowl, Pasadena*
+
+#### Garbage and Noel Gallagher w/Metric
+
+June 2, White River Amphitheatre, Auburn, WA
+
+This was a dual-headliner (Garbage and Noel Gallagher’s post-Oasis band) with (my favorite band) Metric opening. We did a quick one-night trip over to Seattle for this show.
+
+![Metric at White River Amphitheatre Auburn WA](https://cdn-images-1.medium.com/max/800/1*wxUqL69R5xY4aT-lsp0ILA.jpeg)
+*Metric, June 2, 2023, White River Amphitheatre, Auburn, WA*
+
+![Metric performing at White River Amphitheatre](https://cdn-images-1.medium.com/max/800/1*MHlSd46btnVMQ4tAnHQsuA.jpeg)
+*Metric, June 2, 2023, White River Amphitheatre, Auburn, WA*
+
+![Garbage at White River Amphitheatre Auburn WA](https://cdn-images-1.medium.com/max/800/1*n8yFM68FeUxZ1-QXVechxw.jpeg)
+*Garbage, June 2, 2023, White River Amphitheatre, Auburn, WA*
+
+#### Billy Idol
+
+August 28, Spokane Pavilion, Spokane
+
+I noted above that we’d missed Billy Idol because of simultaneous set times at Cruel World; Billy announced his summer tour days later and came to Spokane for a fantastic outdoor show.
+
+![Billy Idol at Spokane Pavilion](https://cdn-images-1.medium.com/max/800/1*8-btlXT7geVQaLxw2krWiw.jpeg)
+*Billy Idol  
+August 28, 2023, Spokane Pavilion, Spokane / Andrew Rich*
+
+![Billy Idol performing at Spokane Pavilion](https://cdn-images-1.medium.com/max/800/1*Aiet95hImKOxgGnLSgwjPQ.jpeg)
+*Billy Idol  
+August 28, 2023, Spokane Pavilion, Spokane / Andrew Rich*
+
+#### Metric
+
+October 12, The Roxy, Los Angeles
+
+My favorite band in the world announced a limited tour of small-club shows celebrating the 20th anniversary of “Old World Underground, Where Are You Now?” and the release of “Formentera II.” Despite a smaller-scale Swiftian nightmare of broken web apps and scalped presale tickets, I managed to grab a pair, and we took a one-night trip to Los Angeles.
+
+We were three rows back from the stage in this tiny club. I’ve never been so close nor so profoundly affected at a show. It was a pretty terrific way to celebrate my birthday!
+
+![Metric at The Roxy Los Angeles](https://cdn-images-1.medium.com/max/800/1*Cam3A9PNGef_vtj1EqpskQ.jpeg)
+*Metric  
+October 12, 2023, The Roxy, Los Angeles / Andrew Rich*
+
+![Metric performing at The Roxy Los Angeles](https://cdn-images-1.medium.com/max/800/1*kcrNq1anf5DWuGJwDLoIIA.jpeg)
+*Metric  
+October 12, 2023, The Roxy, Los Angeles / Andrew Rich*
+
+![Metric on stage at The Roxy Los Angeles](https://cdn-images-1.medium.com/max/800/1*7P9oaPyBWR_AYSUZnNFjhA.jpeg)
+*Metric  
+October 12, 2023, The Roxy, Los Angeles / Andrew Rich*
+
+![Metric live at The Roxy Los Angeles](https://cdn-images-1.medium.com/max/800/1*m5IdNTQu1pooWg_ofk14Kw.jpeg)
+*Metric  
+October 12, 2023, The Roxy, Los Angeles / Andrew Rich*
+
+![Metric concert at The Roxy Los Angeles](https://cdn-images-1.medium.com/max/800/1*aivGLgA3sZVgwEALuQLR3A.jpeg)
+*Metric  
+October 12, 2023, The Roxy, Los Angeles / Andrew Rich*
+
+![Metric band photo at The Roxy Los Angeles](https://cdn-images-1.medium.com/max/800/1*nCPT-3CSS4P07o0Jx7KkgQ.jpeg)
+*Metric  
+October 12, 2023, The Roxy, Los Angeles / Andrew Rich*
+
+![Jen and Andrew after Metric at The Roxy Los Angeles](https://cdn-images-1.medium.com/max/800/1*ZJaLbMbc5Y6615f5tKuxXA.jpeg)
+*Jen and I, after Metric  
+October 12, 2023, The Roxy, Los Angeles / Andrew Rich*
+
+It’s shaping up to be another great year in live music! So far in 2024, we’ve already seen the following:
+
+- Randy Rainbow (Feb 1, Spokane)
+- Madonna: The Celebration Tour (Feb 17, Seattle)
+- Silversun Pickups w/Hello Mary (Feb 18, Spokane)
+
+On the calendar for the rest of the year, we have:
+
+- Metric: Days of Oblivion (May 15, Denver)
+- Whose Live Anyway? (June 28, Spokane)
+- Alvvays w/The Beths (August 21, Spokane)
+- Taylor Swift: The Eras Tour (December 6, Vancouver, BC)
+
+And I’m always watching [Bandsintown](https://bandsintown.com/) and [Seated](https://www.seated.com/) for local (and local-ish) shows. You can find me on [Instagram](https://instagram.com/smartwatermelon). Happy Spring!

--- a/src/content/blog/2025-01-06-2024-in-live-music.md
+++ b/src/content/blog/2025-01-06-2024-in-live-music.md
@@ -1,0 +1,149 @@
+---
+title: "2024 In Live Music"
+date: 2025-01-06
+description: "In 2024, I attended nine live music performances, including 14 artists — here’s a wrap-up!"
+tags: ["blog", "music"]
+mediumUrl: "https://medium.com/@smartwatermelon/2024-in-live-music-d9ed3bade7ee"
+---
+
+### 2024 In Live Music
+
+In 2024, I attended nine live music performances, including 14 artists ([2023’s wrap-up is here](https://medium.com/@smartwatermelon/my-2023-in-live-music-8e83b84ba899)). Only three (Alvvays, Straight No Chaser, and Taylor Swift) were repeats; the rest were new to me. Three shows were at new-to-me venues (Paramount Theatre, Seattle; BECU Live, Spokane; and BC Place, Vancouver, BC); the rest were revisits. As always, I’m referencing my [setlist.fm logs](https://www.setlist.fm/user/smartwatermelon) and [Swarm](https://swarmapp.com/) check-ins.
+
+#### Randy Rainbow: Randy Rainbow for President
+
+February 1; Martin Woldson Theater at The Fox, Spokane, WA, USA
+
+![Randy Rainbow at Martin Woldson Theater at The Fox](https://cdn-images-1.medium.com/max/800/1*UPs9i7Za8sWWbOWDU6FWJg.jpeg)
+*Randy Rainbow at Martin Woldson Theater at The Fox*
+
+#### Madonna: The Celebration Tour
+
+February 17; Climate Pledge Arena, Seattle, WA, USA
+
+![Jen and Andrew at Climate Pledge Arena for Madonna](https://cdn-images-1.medium.com/max/800/1*41eTWtIrF7bMkSp8Oujfxg.jpeg)
+*Jen and I (notice the vintage “Dick Tracy: Admit One” tee) at Climate Pledge Arena, for Madonna*
+
+![Madonna at Climate Pledge Arena Seattle](https://cdn-images-1.medium.com/max/800/1*WShi23Jbv_hNxZyGh4tqVg.jpeg)
+*Madonna at Climate Pledge Arena*
+
+![Madonna performing Ray of Light at Climate Pledge Arena](https://cdn-images-1.medium.com/max/800/1*PtHO9Aeam9v8Kq1N26pZrw.jpeg)
+*Madonna performing “Ray of Light” at Climate Pledge Arena*
+
+#### Silversun Pickups: Physical Thrills Tour (w/Hello Mary)
+
+February 18; Knitting Factory, Spokane, WA, USA
+
+![Hello Mary opening for Silversun Pickups at Knitting Factory](https://cdn-images-1.medium.com/max/800/1*lRjmy4bpE5LOZFKbtrRT2Q.jpeg)
+*Hello Mary opening for Silversun Pickups at Knitting Factory*
+
+![Silversun Pickups at Knitting Factory Spokane](https://cdn-images-1.medium.com/max/800/1*yBjER2NlTskkui66rvGGhQ.jpeg)
+*Silversun Pickups at Knitting Factory*
+
+#### Idina Menzel: Take Me Or Leave Me Tour
+
+July 19; Paramount Theatre, Seattle, WA, USA
+
+![Idina Menzel on the marquee at Paramount Theatre Seattle](https://cdn-images-1.medium.com/max/800/1*XRqbSOers0QtvtLh7QkZZg.jpeg)
+*Idina Menzel on the marquee at Paramount Theatre*
+
+![Idina Menzel at Paramount Theatre Seattle](https://cdn-images-1.medium.com/max/800/1*ARCCIsAbCMAr8VK8WspULQ.jpeg)
+*Idina Menzel at Paramount Theatre*
+
+![Idina Menzel performing at Paramount Theatre Seattle](https://cdn-images-1.medium.com/max/800/1*-yyo5aeqD4jT8LK1orKJrg.jpeg)
+*Idina Menzel at Paramount Theatre*
+
+#### Alvvays: US Tour Summer 2024 (w/The Beths)
+
+August 21; Knitting Factory, Spokane, WA, USA
+
+![The Beths opening for Alvvays at Knitting Factory Spokane](https://cdn-images-1.medium.com/max/800/1*g14qx9iBhktGUUZx_tUiOg.jpeg)
+*The Beths opening for Alvvays at Knitting Factory*
+
+![Alvvays at Knitting Factory Spokane](https://cdn-images-1.medium.com/max/800/1*ZJ5Aq3EV-kIThh87Mdz-tA.jpeg)
+*Alvvays at Knitting Factory*
+
+![Molly Rankin of Alvvays at Knitting Factory Spokane](https://cdn-images-1.medium.com/max/800/1*3kvNfYnC-mmGMV7hIgUbnw.jpeg)
+*Molly Rankin of Alvvays at Knitting Factory*
+
+#### Lindsey Stirling: The Duality Tour (w/Saint Motel)
+
+August 31; BECU Live at Northern Quest Resort & Casino, Airway Heights, WA, USA
+
+![Saint Motel opening for Lindsey Stirling at BECU Live](https://cdn-images-1.medium.com/max/800/1*7bNXd12IEaFG9TdH8NGSwQ.jpeg)
+*Saint Motel opening for Lindsey Stirling at BECU Live at Northern Quest Resort & Casino*
+
+![Lindsey Stirling at BECU Live at Northern Quest](https://cdn-images-1.medium.com/max/800/1*uxdFY34vvQZraVQZQyCTgA.jpeg)
+*Lindsey Stirling at BECU Live at Northern Quest Resort & Casino*
+
+![Lindsey Stirling performing at BECU Live at Northern Quest](https://cdn-images-1.medium.com/max/800/1*wZS5hyMzQaigbaRHqWs_Gw.jpeg)
+*Lindsey Stirling at BECU Live at Northern Quest Resort & Casino*
+
+#### Pentatonix (w/Loren Allred)
+
+September 11; BECU Live at Northern Quest Resort & Casino, Airway Heights, WA, USA
+
+![Loren Allred opening for Pentatonix at BECU Live](https://cdn-images-1.medium.com/max/800/1*Sx1ZRHQpJJqoKQcGfjZN7w.jpeg)
+*Loren Allred opening for Pentatonix at BECU Live at Northern Quest Resort & Casino*
+
+![Pentatonix at BECU Live at Northern Quest](https://cdn-images-1.medium.com/max/800/1*uEjBfTWb7dFUZC42cVIEdA.jpeg)
+*Pentatonix at BECU Live at Northern Quest Resort & Casino*
+
+![Pentatonix performing at BECU Live at Northern Quest](https://cdn-images-1.medium.com/max/800/1*pjsqvaLfMI-k9VEiO9yGpQ.jpeg)
+*Pentatonix at BECU Live at Northern Quest Resort & Casino*
+
+#### Straight No Chaser: Top Shelf Tour
+
+November 23; Pend Oreille Pavilion, Airway Heights, WA, USA
+
+![Jennifer, Jen, and Andrew outside Pend Oreille Pavilion for Straight No Chaser](https://cdn-images-1.medium.com/max/800/1*jyRk7sFW-j8aehjYA7FbZA.jpeg)
+*Jennifer, Jen, and me outside Pend Oreille (“pon-de-ray”) Pavilion for Straight No Chaser*
+
+![Straight No Chaser at Pend Oreille Pavilion](https://cdn-images-1.medium.com/max/800/1*c2kYjWqsx5x7fh-Ibo_Dug.jpeg)
+*Straight No Chaser at Pend Oreille Pavilion*
+
+![Straight No Chaser performing at Pend Oreille Pavilion](https://cdn-images-1.medium.com/max/800/1*lhOkEcTrJDCIJ2Cj7_dsKg.jpeg)
+*Straight No Chaser at Pend Oreille Pavilion*
+
+#### Taylor Swift: The Eras Tour (w/Gracie Abrams)
+
+December 6; BC Place Stadium, Vancouver, BC, Canada
+
+![Jen and Andrew at an Eras Tour themed installation in Vancouver](https://cdn-images-1.medium.com/max/800/1*7-_RobtyaYffnEuEKWSU2Q.jpeg)
+*Jen and me at one of the many “Eras Tour”-themed installations around Vancouver*
+
+![Phone showing Taylor Swift Eras Tour ticket confirmation](https://cdn-images-1.medium.com/max/800/1*U3qWe8A68TyToaCn2cZSnQ.jpeg)
+*My phone reminding me how amazing this is going to be*
+
+![Pre-show floor merch line at BC Place Stadium](https://cdn-images-1.medium.com/max/800/1*dBV_JT5cS12igqe-wrinyg.jpeg)
+*In the pre-show floor merch line at BC Place Stadium*
+
+![BC Place Stadium before Taylor Swift takes the stage](https://cdn-images-1.medium.com/max/800/1*LTc4iZr0N5PHXayBPysEAA.jpeg)
+*Are you ready for it? Show about to start.*
+
+![Taylor Swift takes the stage at BC Place Stadium](https://cdn-images-1.medium.com/max/800/1*YcbbasBpSxHBE4X4Id9Vkw.jpeg)
+*Taylor Swift takes the stage at BC Place Stadium*
+
+![This is NOT Taylor's Version sign at the Eras Tour](https://cdn-images-1.medium.com/max/800/1*Q1ctVRlvoIopyNJSJFl0bg.jpeg)
+*“This is NOT Taylor’s Version”*
+
+![Taylor Swift performing at BC Place Stadium](https://cdn-images-1.medium.com/max/800/1*9r7ohxjt5TUPS6nByJlO2Q.jpeg)
+*Taylor Swift at BC Place Stadium*
+
+![Taylor Swift on stage at BC Place Stadium](https://cdn-images-1.medium.com/max/800/1*VUoF66G2iBVHGjJPXsblBA.jpeg)
+*Taylor Swift at BC Place Stadium*
+
+![Taylor Swift at the Eras Tour BC Place Stadium](https://cdn-images-1.medium.com/max/800/1*UcEBMLddCFtxclqGqu0rKg.jpeg)
+*Taylor Swift at BC Place Stadium*
+
+![Farewell from BC Place Stadium after the Eras Tour](https://cdn-images-1.medium.com/max/800/1*WXdZ-c_KJ343X9RoNqN0Lg.jpeg)
+*Farewell from BC Place Stadium*
+
+From niche indie bands to the highest-grossing concert tour in history, 2024 was a wild year for me in live music. Coming up in 2025, so far:
+
+- **Hamilton**
+  April 8; First Interstate Center for the Arts, Spokane
+- **Kylie Minogue: Tension Tour**
+  April 25; Climate Pledge Arena, Seattle
+
+I always watch [Bandsintown](https://bandsintown.com/) and [Seated](https://www.seated.com/) for local (and local-ish) shows. You can find me on [Instagram](https://instagram.com/smartwatermelon). Happy New Year!

--- a/src/content/blog/2025-01-23-automating-macos-security-dialogs-a-tale-of-yak-shaving-and-applescript.md
+++ b/src/content/blog/2025-01-23-automating-macos-security-dialogs-a-tale-of-yak-shaving-and-applescript.md
@@ -1,0 +1,138 @@
+---
+title: "Automating macOS Security Dialogs: A Tale of Yak Shaving and AppleScript"
+date: 2025-01-23
+description: "TL;DR: Created an AppleScript to click “Allow” on recurring nginx security prompts automatically."
+tags: ["blog", "tech"]
+mediumUrl: "https://medium.com/@smartwatermelon/automating-macos-security-dialogs-a-tale-of-yak-shaving-and-applescript-759300d6fba9"
+---
+
+### Automating macOS Security Dialogs: A Tale of Yak Shaving and AppleScript
+
+**TL;DR**: Created an AppleScript to click “Allow” on recurring nginx security prompts automatically. Required UI Browser (a deprecated tool) to identify UI elements. Here’s how to get it working:
+
+1. Install UI Browser despite Homebrew deprecation
+2. Create AppleScript service to handle dialogs
+3. Set up LaunchAgent to run automatically
+
+![macOS security dialog asking to allow nginx incoming network connections](https://cdn-images-1.medium.com/max/800/1*P7h9fuubFNEVL7-R6M726A.png)
+*The annoying dialog in question. I don’t know why it’s tinted pink.*
+
+### The Problem
+
+Running nginx on macOS 12.7.6 (Monterey) on a Mac Mini (Late 2014, Macmini7,1) presents a specific UX issue. Because this hardware can’t run newer macOS versions, and Homebrew must build nginx from source instead of using pre-built bottles, every nginx restart triggers a macOS firewall permission dialog.
+
+In a server context, we must remember to remote desktop into the server and click the Allow button. If we can’t access the server’s desktop for whatever reason, our nginx simply won’t accept connections.
+
+> **Technical Context**: Homebrew often builds packages from source on older macOS versions when pre-built bottles aren’t available for that OS version. This can trigger different behavior than bottle-installed versions of the same software.
+
+### The Solution Journey
+
+### Step 1: The UI Browser Challenge
+
+The first obstacle was identifying the correct UI elements to manipulate. AppleScript needs precise element references, but macOS’s built-in Accessibility Inspector proved insufficient. This led to our first yak-shaving exercise:
+
+```
+# Attempt to install UI Browser  
+brew install ui-browser --cask  
+# Disabled because it is discontinued upstream! It was disabled on 2024-12-16.
+```
+
+The solution required editing Homebrew’s cask formula:
+
+```
+# Tap the Caskroom to get formula definition  
+brew tap --force homebrew/cask  
+# Edit the formula  
+brew edit ui-browser --cask  
+
+# Comment out the disable line  
+# disable! date: "2024-12-16", because: :discontinued  
+
+# Install UI Browser  
+brew install ui-browser --cask
+```
+
+### Step 2: Building the Automation
+
+With UI Browser installed, we could identify the correct element path:
+
+tell application "System Events"  
+
+```
+    tell process "UserNotificationCenter"  
+        if exists window 1 then  
+            set dialogText to value of static text 1 of window 1  
+            if dialogText contains "nginx" and dialogText contains "accept incoming network connections" then  
+                click UI element "Allow" of window 1  
+                # Optional notification; brew install terminal-notifier  
+                do shell script "/usr/local/bin/terminal-notifier -message 'Allowed nginx connections' -title 'Nginx Allow Script'"  
+            end if  
+        end if  
+    end tell  
+end tell
+```
+
+Save this as `$HOME/bin/allow-nginx.scpt`
+
+### Step 3: System Integration
+
+Created a LaunchAgent to run the script periodically:
+
+<?xml version="1.0" encoding="UTF-8"?>  
+
+```
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN">  
+<plist version="1.0">  
+<dict>  
+    <key>Label</key>  
+    <string>com.local.allow-nginx</string>  
+    <key>ProgramArguments</key>  
+    <array>  
+        <string>/Users/YOUR_USERNAME/bin/allow-nginx.scpt</string>  
+    </array>  
+    <key>StartInterval</key>  
+    <integer>60</integer>  
+    <key>RunAtLoad</key>  
+    <true/>  
+</dict>  
+</plist>
+```
+
+Save this as `$HOME/Library/LaunchAgents/com.local.allow-nginx.plist`
+
+Install the service and test:
+
+launchctl load $HOME/Library/LaunchAgents/com.local.allow-nginx.plist  
+sudo nginx -s stop && sudo nginx
+
+The network connection dialog should appear and vanish within 60 seconds.
+
+### Hardware and Software Context
+
+This issue specifically manifests on:
+
+- Hardware: Mac Mini Late 2014 (Macmini7,1)
+- OS: macOS 12.7.6 (Monterey) — the last supported version for this Mac model
+- nginx: Built from source via Homebrew
+
+*Note: Users running newer macOS versions with bottle-installed nginx may not encounter this issue. This solution addresses a specific intersection of older hardware, OS limitations, and Homebrew’s build behavior.*
+
+### Lessons Learned
+
+1. **Deprecated Tools Still Matter**: Sometimes, the best tool for the job is discontinued. Don’t be afraid to work around deprecation warnings when necessary.
+2. **Security vs. Convenience**: While macOS’s security model is robust, development workflows often require automation of security dialogs.
+3. **AppleScript Lives On**: Despite its age, AppleScript remains vital for macOS automation, especially for UI interactions.
+
+### Broader Implications
+
+This solution highlights a common tension in software development: balancing security with developer experience. While macOS’s security model protects users, it can impede development workflows. Automation bridges this gap without compromising the underlying security model.
+
+*Note: You should use this workaround cautiously and only in development environments where you understand the security implications.*
+
+### References and Resources
+
+An incomplete list of articles and posts I used while working on this.
+
+- [Can you install disabled Homebrew packages?](https://stackoverflow.com/questions/73586208/can-you-install-disabled-homebrew-packages)
+- [If a dialog exists, click certain button with Applescript](https://stackoverflow.com/questions/64651654/if-a-dialog-exists-click-certain-button-with-applescript)
+- [UI Browser](https://latenightsw.com/freeware/ui-browser/) (deprecated)

--- a/src/content/blog/2025-09-24-when-your-mac-admin-password-isnt-accepted-until-you-reset-securetoken.md
+++ b/src/content/blog/2025-09-24-when-your-mac-admin-password-isnt-accepted-until-you-reset-securetoken.md
@@ -1,0 +1,70 @@
+---
+title: "When Your Mac Admin Password Isn’t Accepted… Until You Reset SecureToken"
+date: 2025-09-24
+description: "On macOS, there’s nothing more frustrating than typing your known admin password into a system dialog — only to have it rejected, over and…"
+tags: ["blog", "tech"]
+mediumUrl: "https://medium.com/@smartwatermelon/when-your-mac-admin-password-isnt-accepted-until-you-reset-securetoken-0fab39646f0e"
+---
+
+### When Your Mac Admin Password Isn’t Accepted… Until You Reset SecureToken
+
+On macOS, there’s nothing more frustrating than typing your known admin password into a system dialog — only to have it rejected, over and over. I experienced this annoyance while attempting to enable the “Allow JavaScript from Apple Events” setting in Safari’s Developer options. Even more confounding: my account was an administrator, my password worked for login and `sudo`, and yet every GUI authentication window (including Software Update) stubbornly refused to recognize it.
+
+#### The Symptom
+
+Here’s what I saw — this password dialog from Safari, demanding my credentials, and persistently rejecting them:
+
+![Safari is trying to allow Apple Events to run JavaScript on web pages. Enter the password for the user “TILSIT Operator” to allow this.](https://cdn-images-1.medium.com/max/800/1*N8HbaS0UP-EoGaGM-V7e0w.png)
+*I AM entering the password!*
+
+Does that look familiar? It might, if you’ve struggled with advanced macOS settings, particularly after system upgrades, account migrations, or changes to device management.
+
+#### Diagnosing the True Cause
+
+After checking the basics — physical access, correct password, admin group membership, TCC resets, and countless reboots — I made a key discovery: a different admin account on the same Mac worked just fine; only one user was seeing the problem.
+
+Digging deeper, I learned this wasn’t just a permissions issue or TCC corruption. The culprit was SecureToken, Apple’s cryptographic user authentication feature introduced for FileVault and privacy-related operations. If your admin account lacks SecureToken, it may be able to log in and use Terminal, but system password dialogs will fail — silently and stubbornly.
+
+SecureToken is distinct from FileVault and Mobile Device Management (MDM) privileges, although it’s deeply intertwined with both. An account may have FileVault unlock capability or MDM admin permissions, yet lack SecureToken, resulting in unexpected authentication failures in GUI dialogs — especially in enterprise-managed environments.
+
+A quick check in Terminal (replace USER with your account shortname):  
+`sysadminctl -secureTokenStatus USER`
+If you see `ENABLED` you’re fine. If not: that’s the bugbear blocking you!
+
+#### The Solution: Restore SecureToken
+
+I followed this approach, using a working admin account:
+
+1. Log in locally (not via screen sharing or remote desktop) on a SecureToken-enabled admin account — the one where you can successfully run Software Update, enable Safari settings, etc.
+2. Open Terminal and run:  
+
+```
+    `sudo sysadminctl -secureTokenOff USER -password USER_PASSWORD interactive`   
+    (substitute the affected user’s name and password for USER and USER_PASSWORD)  
+    macOS will prompt for GUI authentication (Touch ID/password).
+3.  Continue by activating the secureToken:  
+    `sudo sysadminctl -secureTokenOn USER -password USER_PASSWORD interactive`   
+    (substitute the affected user’s name and password for USER and USER_PASSWORD)  
+    macOS will prompt for GUI authentication (Touch ID/password).
+4.  Verify the change was successful:  
+    `sysadminctl -secureTokenStatus USER`   
+    You should now see `Secure token is ENABLED for user`
+5.  Log out, then back in to the affected account. Now, authentication dialogs should accept your password everywhere: Safari, System Settings, Software Update, and beyond.
+```
+
+#### Lessons and References
+
+This experience is well documented — if you know what to search for. In particular, the Apple sysadmin and JAMF communities highlight SecureToken quirks as a root cause for GUI password failures even for admin users:  
+ • “[Unable to remove secure token from a user](https://community.jamf.com/general-discussions-2/unable-to-remove-secure-token-from-a-user-30833)” — JAMF Community  
+ • Reddit: [Admin password not accepted for System Preferences](https://www.reddit.com/r/macsysadmin/comments/10k3zaz/admin_password_not_accepted_via_system_preferences/)
+
+Unfortunately, there are quite a large number of blandly informative yet completely unhelpful articles that suggest endless reboots, resetting TCC, or even deleting the affected account. I’m here to tell you those suggestions are either useless or indeed harmful.
+
+### Conclusion
+
+If your admin account can’t authenticate password dialogs, and another admin account works, check SecureToken first. Fixing it is usually just a command away. You’ll save hours of head-scratching, blind alleys, and cursing the wisdom of the ancients.
+
+![Relevant xkcd comic about finding an unanswered forum post from years ago](https://cdn-images-1.medium.com/max/800/1*J3Ygm52dcu75LQkQ6McuEw.png)
+*[https://xkcd.com/979/](https://xkcd.com/979/)*
+
+Endnote: I solved this problem during a thorough rubber-ducking session with Perplexity AI, which also aided in drafting the article. I don’t miss working in an office, but it’s sometimes nice to have a coworker to bounce ideas off.

--- a/src/content/blog/2026-01-01-2025-in-live-music-and-comedy.md
+++ b/src/content/blog/2026-01-01-2025-in-live-music-and-comedy.md
@@ -1,0 +1,120 @@
+---
+title: "2025 in Live Music and Comedy"
+date: 2026-01-01
+description: "My 2025 live music/comedy recap!"
+tags: ["blog", "music"]
+mediumUrl: "https://medium.com/@smartwatermelon/2025-in-live-music-and-comedy-15bc9108a8b2"
+---
+
+### 2025 in Live Music and Comedy
+
+In 2025, I attended eight live performances — five music and three comedy — featuring ten artists (2024’s [wrap-up is here](https://smartwatermelon.medium.com/2024-in-live-music-d9ed3bade7ee)). This was my first year adding comedy to these wrap-ups, though it’s always been part of how we spend our entertainment time. As always, I’m referencing my [setlist.fm](https://www.setlist.fm/attended/smartwatermelon) logs and Swarm check-ins.
+
+### Kevin Smith
+
+**January 1; Spokane Comedy Club, Spokane, WA, USA**
+
+![Spokane Comedy Club marquee](https://cdn-images-1.medium.com/max/800/1*5FEN6Ke9qthUAxSSYCwYKg.jpeg)
+*Spokane Comedy Club marquee / Andrew Rich*
+
+What better way to start the new year than with Kevin Smith holding court at a comedy club? #SpokaneAmendment
+
+### Hamilton
+
+**April 8; First Interstate Center for the Arts, Spokane, WA, USA**
+
+![The cast of Hamilton taking their bow](https://cdn-images-1.medium.com/max/800/1*TqCdpCu6Ss-s-jvnZcqJyg.jpeg)
+*The cast of Hamilton takes their bow at the conclusion of the show / Andrew Rich*
+
+Our second time seeing Hamilton; the first was in San Francisco in 2019. Unfortunately, they haven’t fixed the ending yet.
+
+### Kylie Minogue: Tension Tour (w/Rita Ora)
+
+**April 25; Climate Pledge Arena, Seattle, WA, USA**
+
+![Floor seats for Kylie Minogue at Climate Pledge Arena](https://cdn-images-1.medium.com/max/800/1*RYwLHZXKpGblFjzyfzHXFw.jpeg)
+*Pretty great floor seats for Kylie Minogue at Climate Pledge Arena / Andrew Rich*
+
+Climate Pledge Arena has become our go-to for major shows — it’s a 48-minute flight from Spokane, a 30-minute light rail ride to downtown, and a fun monorail ride to the arena. We’ll fly out in the afternoon, have dinner, see the show, stay overnight, and fly home the next morning. We’d previously seen Madonna there in 2024, and we’d be back in August for Lady Gaga.
+
+![Kylie Minogue performing at Climate Pledge Arena](https://cdn-images-1.medium.com/max/800/1*EYM5FekrSh4h69x5HDE71g.jpeg)
+*Kylie Minogue performing at Climate Pledge Arena / Andrew Rich*
+
+Kylie is a legend, of course, and I’m so glad we got to see her live. The Tension tour highlighted her current album and was also a fun retrospective of her career.
+
+### Silversun Pickups (w/Rocket)
+
+**May 4; Knitting Factory, Spokane, WA, USA**
+
+![Silversun Pickups at Knitting Factory Spokane](https://cdn-images-1.medium.com/max/800/1*cfr8uQnY_vUrDk6xQljVxg.jpeg)
+*Silversun Pickups at Knitting Factory, Spokane / Andrew Rich*
+
+Silversun Pickups were back at the Knitting Factory for the second year in a row. They mentioned how much they love playing in Spokane and that they always try to include it on their tours. The set featured a couple of new songs, and Brian Aubert jammed a bit with opener Rocket, which was extra fun.
+
+![Rocket featuring Brian Aubert of Silversun Pickups](https://cdn-images-1.medium.com/max/800/1*-YPVb3ycqbsGi2eyG1ePdA.jpeg)
+*Rocket, featuring Silversun Pickups’ Brian Aubert / Andrew Rich*
+
+### Lady Gaga
+
+**August 6; Climate Pledge Arena, Seattle, WA, USA**
+
+![Lady Gaga preparing for Mayhem](https://cdn-images-1.medium.com/max/800/1*iYeFSa8mFmnYD-JnQuvVMw.jpeg)
+*Lady Gaga preparing for Mayhem / Andrew Rich*
+
+Back to Climate Pledge for our second Seattle trip of the year.
+
+![Lady Gaga performing on stage](https://cdn-images-1.medium.com/max/800/1*Th59kiWytJPlCkgsh9YTrQ.jpeg)
+*Lady GagaThe whole show was pretty much like this, if not more so / Andrew Rich*
+
+![Lady Gaga in a vintage Depeche Mode tee during encore](https://cdn-images-1.medium.com/max/800/1*z2YX5CK4F0F6jkDEUhNjQw.jpeg)
+*Lady Gaga came out for the encore in a vintage Depeche Mode tee / Andrew Rich*
+
+### Garbage (w/Starcrawler)
+
+**October 18; Knitting Factory, Spokane, WA, USA**
+
+![Shirley Manson of Garbage at the Knitting Factory Spokane](https://cdn-images-1.medium.com/max/800/1*dGZGibInsBK7cyiRe5vPGw.jpeg)
+*Shirley Manson of Garbage at the Knitting Factory, Spokane / Andrew Rich*
+
+This was my third time seeing Garbage — after Oakland in 2018 and Auburn, Washington in 2023. Sadly, Shirley Manson indicated this would likely be their last North American tour, citing increased costs that have become prohibitive for anyone not at a mega-label scale. If that’s true, I’m glad we caught them.
+
+![Garbage setlist from the Knitting Factory](https://cdn-images-1.medium.com/max/800/1*GQLF1PT4idAHolitqugfYA.jpeg)
+*Garbage’s setlist from the Knitting Factory / Andrew Rich*
+
+### Iliza Shlesinger
+
+**November 21; Arlene Schnitzer Concert Hall, Portland, OR, USA**
+
+![The Arlene Schnitzer theater in Portland Oregon](https://cdn-images-1.medium.com/max/800/1*5Ni2I3WJc3HSULxiqY41qw.jpeg)
+*The Arlene Schnitzer theater, Portland, Oregon / Andrew Rich*
+
+A one-night trip to Portland for Iliza at the Schnitzer, a gorgeous old restored theater. She was great live, but the material was almost entirely drawn from her recent Prime special — so it was a little anticlimactic to know all the jokes before she told them.
+
+![Iliza Shlesinger at the Arlene Schnitzer theater](https://cdn-images-1.medium.com/max/800/1*IfHq9da0xqNjV_jTJGPMAg.jpeg)
+*Iliza Shlesinger at the Arlene Schnitzer theater, Portland, Oregon / Andrew Rich*
+
+### Paula Poundstone
+
+**December 5; Bing Crosby Theater, Spokane, WA, USA**
+
+![Spokane Bing Crosby theater](https://cdn-images-1.medium.com/max/800/1*BrinJFCFI5-l-b1PHoBSWQ.jpeg)
+*Spokane’s beautiful Bing Crosby theater / Andrew Rich*
+
+Another beautiful restored theater, this one right here in Spokane. We’ve been fans of Paula since her early Comedy Central and HBO specials, and it was a real treat to see her live.
+
+Metric pulled out of a June co-headlining tour due to a dispute with their tour partner, which meant I didn’t get to see my favorite band in either 2024 or 2025. I’m really hoping Emily Haines’s hints about a new release and 2026 tour dates materialize¹.
+
+Speaking of 2026, here’s what’s already on the calendar:
+
+- [**Lights**](https://www.bandsintown.com/e/107395585-lights-at-the-showbox-seattle-wa) — February 18; Showbox, Seattle
+- [**Florence + The Machine**](https://www.bandsintown.com/e/1036950813-florence-and-the-machine-at-climate-pledge-arena-garage-seattle-wa) — May 12; Climate Pledge Arena, Seattle
+- [**Purity Ring: Place Of My Own Tour**](https://www.bandsintown.com/e/107845081-purity-ring-at-knitting-factory-spokane-spokane-wa?came_from=257&utm_medium=web&utm_source=home&utm_campaign=event) — May 23; The Knitting Factory, Spokane
+- [**Ladytron**](https://www.bandsintown.com/e/1037463474-ladytron-at-neptune-theatre-seattle-wa) — May 31; Neptune Theatre, Seattle
+- [**Metric: All The Feelings Tour**](https://go.seated.com/tour-events/d6ba95e9-dda0-4059-8c71-cd21d9c68a3a) — June 16; Greek Theater, Los Angeles
+- [**Nikki Glaser: The Stunning Tour**](https://firstinterstatecenter.org/event/nikki-glaser-the-stunning-tour/) — November 22; FICA Spokane
+
+I always watch [Bandsintown](https://bandsintown.com/) and [Seated](https://www.seated.com/) for local (and local-ish) shows. You can find me on [Instagram](https://instagram.com/smartwatermelon). Happy New Year!
+
+```
+[1] Metric announced a [summer tour,](https://www.ilovemetric.com/tour) and we’ll be at the Greek Theater in Los Angeles. In the pit. I can’t wait.
+```

--- a/src/content/blog/2026-01-24-baumgartner-must-go.md
+++ b/src/content/blog/2026-01-24-baumgartner-must-go.md
@@ -1,0 +1,70 @@
+---
+title: "Baumgartner Must Go"
+date: 2026-01-24
+description: "Rep. Baumgartner on Federal Agent Violence"
+tags: ["blog"]
+mediumUrl: "https://medium.com/@smartwatermelon/baumgartner-must-go-ca74f0f7ec3a"
+---
+
+### Baumgartner Must Go
+
+**Rep. Baumgartner on Federal Agent Violence**
+
+_His statements. His votes. The pattern._
+
+![Official portrait of U.S. Representative Michael Baumgartner](https://cdn-images-1.medium.com/max/800/1*AW0prVNZk_ftplZVWDkA3Q.jpeg)
+_Photo credit: Official portrait, Office of U.S. Representative Michael Baumgartner. Via baumgartner.house.gov._
+
+**Renee Good (January 7, 2026)**
+
+ICE agent Jonathan Ross shot Good three times in her car in south Minneapolis. Mother of three, acting as legal observer. The video contradicts the administration's claims that she used her vehicle as a weapon.
+
+**Baumgartner (Jan 15):** _“Obviously, it’s a tragedy whenever anybody gets killed, but from what I’ve seen, it looks like a justified shooting.”_
+
+On Noem calling Good a _“domestic terrorist”_ without investigation: _“I would like to refrain from making those kinds of comments until there’s an investigation.”_ Trump labeled her a terrorist within hours. No investigation.
+
+**Public opinion:** 53% say the shooting was unjustified. 62% don’t trust the federal government to investigate fairly. (Quinnipiac, Jan 8–12)
+
+**Alex Pretti (January 24, 2026)**
+
+Border Patrol shot Pretti at least ten times in south Minneapolis. ICU nurse at VA hospital. American citizen, legal gun permit, no criminal record. NYT video analysis: he held a phone, not a gun, when agents took him down. The gun was found eight seconds _after_ pinning him.
+
+**Federal response:** DHS claims he intended to _“massacre”_ agents. Stephen Miller: _“would-be assassin.”_ State investigators with a warrant were blocked from the scene.
+
+```
+**Baumgartner:** [No statement as of publication]
+```
+
+**His ICE Positions**
+
+**March 2025, Whitworth town hall:** _“It would be far better for the security of the state of Washington and for immigrants in the state of Washington if Washington was not a sanctuary state.”_ Pledged to _“make that happen.”_
+
+**June 2025, after Spokane ICE arrests:** Blamed sanctuary laws for _“forcing”_ ICE to use _“more aggressive measures.”_ Defended agents who smashed truck windows and Tasered migrants.
+
+**On ICE tactics:** _“ICE has to go and get them in their homes or on the street, where they have to be all loaded up with weapons.”_
+
+**Praising Trump**
+
+**March 2025 SOTU:** _“Tonight’s address celebrated the bold actions taken by President Trump to restore the rule of law.”_
+
+**October 2025:** Co-sponsored H.R.5789, the Donald J. Trump Congressional Gold Medal Act.
+
+**White House visit:** Discussed their _“mutual friend”,_ Coach Mike Leach.
+
+**The Pattern**
+
+Federal agents kill American citizens → Baumgartner calls it “justified” or stays silent.
+
+Administration labels victims “terrorists” without investigation → Baumgartner says he’ll “refrain from commenting.”
+
+State officials demand accountability → Baumgartner calls them “highly irresponsible.”
+
+Constituents confront him → He blames sanctuary laws.
+
+Throughout: Praise for Trump. Gold medal co-sponsorship.
+
+**WA-05 deserves a representative who demands accountability when federal agents kill American citizens — not one who defends the killings before investigations happen.**
+
+_Sources:_ Spokesman-Review (Jan 15, March 17–18, March 31, 2025); New York Times (Jan 24, 2026); KREM (June 2025); Quinnipiac (Jan 8–12, 2026); baumgartner.house.gov
+
+January 24, 2026

--- a/src/content/elections/2014-11-04-my-2014-ballot-choices.md
+++ b/src/content/elections/2014-11-04-my-2014-ballot-choices.md
@@ -1,0 +1,119 @@
+---
+title: "My 2014 Ballot Choices"
+date: 2014-11-04
+description: "Because I know you care"
+tags: ["elections", "politics"]
+mediumUrl: "https://medium.com/@smartwatermelon/my-2014-ballot-choices-146134676e45"
+---
+
+### My 2014 Ballot Choices
+
+_(Updated: I've added a “_[_Results_](#results)_” section below, noting how my picks fared in the election. — A.R. 2014–11–05)_
+
+For the 2014 midterm election in California’s 14th Congressional district, 13th Senate district and 24th Assembly district; county of San Mateo; city of East Palo Alto.
+
+I am registered as “decline to state,” but my political sympathies lie much closer to the Democrats than the Republicans; if there are one of each, the Democrat will almost always get my vote. This post is more about California’s ballot measures (and any local issues as well). For background, see my [2012 election post](http://www.project-insomnia.com/wp/2012/10/18/2012-election-my-ballot/).
+
+A great nonpartisan reference for information on ballot issues is [VotersEdge.org](http://VotersEdge.org), which used to be [SmartVoter.org](http://SmartVoter.org). I don't know why they changed, and the new site is rather less usable for me than the old one, but the information is still valuable.
+
+#### National
+
+- U.S. Representative, 14th Congressional District: Jackie Speier
+
+#### State
+
+- Governor: Edmund G “Jerry” Brown
+- Lieutenant Governor: Gavin Newsom
+- Secretary of State: Alex Padilla
+- Controller: Betty T. Yee
+- Treasurer: John Chiang
+- Attorney General: Kamala D. Harris
+- Insurance Commissioner: Dave Jones
+- Member, State Board of Equalization, 2nd District: Fiona Ma
+- Member of the State Assembly, 24th District: Richard S. Gordon
+- Superintendent of Public Instruction: Tom Torlakson
+
+#### State — Judicial
+
+I literally know nothing about any of these people except Goodwin Liu, so I'm turning to my usual strategy of seeing who else supports or opposes them. In the case of state judicial confirmations, I found [this Daily Kos article](http://www.dailykos.com/story/2014/11/02/1340407/-How-to-pick-the-right-judge-on-November-4) by Susan Grigsby, which in turn links to a couple of conservative-run voter guides for these candidates — so I can vote the opposite way.
+
+- Associate Justice of the Supreme Court — Goodwin Liu: YES
+- Associate Justice of the Supreme Court — Mariano-Florentino Cuéllar: YES
+- Associate Justice of the Supreme Court — Kathryn Mickle Werdegar: YES
+- Presiding Justice of Court of Appeal, District 1, Division 1 — Jim Humes: YES
+- Associate Justice of Court of Appeal, District 1, Division 1 — Kathleen M. Banke: NO
+- Presiding Justice of Court of Appeal, District 1, Division 2 — J. Anthony Kline: YES
+- Associate Justice of Court of Appeal, District 1, Division 2 — Therese M. Stewart: YES
+- Associate Justice of Court of Appeal, District 1, Division 3 — Stuart R. Pollack: YES
+- Associate Justice of Court of Appeal, District 1, Division 3 — Martin J. Jenkins: NO
+- Presiding Justice of Court of Appeal, District 1, Division 4 — Ignazio John Ruvolo: NO
+- Associate Justice of Court of Appeal, District 1, Division 5 — Mark B. Simons: NO
+- Associate Justice of Court of Appeal, District 1, Division 5 — Terence L. Bruiniers: NO
+
+#### Local
+
+With one exception (see note), these are based on candidate statements and endorsements.
+
+- Ravenswood City School District, Members, Governing Board (3): Marcelino Lopez, Ana M. Pulido and Nicolas Valdes
+- City of East Palo Alto, Members, City Council (2): Kimberly Carlton and Donna Rutherford
+- San Mateo County Harbor District, Members, Board of Commissioners, Full Term (2): Robert Bernardo and Nicole David
+- San Mateo County Harbor District, Members, Board of Commissioners, Short Term: Tom Mattusch
+
+#### Statewide Ballot Measures
+
+I have a general “no” bias toward ballot initiatives; I think it’s a poor governing practice. However, laws or regulations which are first enacted by initiative can only be reversed the same way. I don't have enough knowledge on some of these to make a strong case either way, so I'm also looking at what groups support or oppose them.
+
+- Proposition 1 (Water Bond): YES — this is an obvious one. California is in a record drought and the state’s historic lack of investment in water infrastructure is making it worse. This bond will fund water storage and transit projects, as well as watershed and ecological protection.
+- Proposition 2 (Budget Stabilization Account): YES — Jerry Brown’s “rainy day fund”. Silly that this has to be done by initiative, but that’s California for you.
+- Proposition 45 (Health Insurance): YES — this measure gives the state Insurance Commissioner the power to regulate health insurance rates in the same way that auto and home insurance rates are already regulated. Remember when mandatory auto insurance became law and everyone panicked because rates were sure to go up? And then they didn’t? That’s because the insurance commissioner regulates the rates. Now that health insurance is also mandatory, it makes complete sense to me that the rates should be regulated the same way.
+- Proposition 46 (Medical Negligence Lawsuits): NO — I am in favor of indexing the cap on medical malpractice damages to inflation (pretty much everything should be indexed to inflation), but this measure does a whole bunch of other things including mandating drug testing of medical professionals and reporting/checking a state-run database for patient prescriptions. These may or may not be laudable goals, but I don't feel these three issues should be lumped together into one large, hard-to-understand ballot initiative.
+- Proposition 47 (Criminal Sentences): YES — this measure reduces penalties for some non-violent / non-serious offenses from felonies to misdemeanors. This means less tax money spent on keeping people in state prison, perpetuating the criminal revolving door syndrome (where some who didn't start out as violent offenders become violent or dangerous as a result of incarceration), and fewer lives ruined by felony convictions.
+- Proposition 48 (Indian Gaming): NO — I don't have a strong opinion on the merits of this (which biases me toward a No vote) and I don't like that the new casinos would apparently have exemptions from the California Environmental Quality Act.
+
+#### Local Ballot Measures
+
+- Measure H (San Mateo County Community College District Bond): YES — I am loathe to add more special assessments to my property tax bill, but the San Mateo County Community Colleges needs funding to operate and upgrade its facilities (and my wife attends Cañada College), and this is how they get that funding. And the Silicon Valley Taxpayers Association, which is affiliated with the Jarvis association, is against it.
+
+And that’s it for me. No matter whether you agree with me or not, don't forget to go out and vote!
+
+### Results
+
+Only talking about the candidates and issues on which I voted. Obviously a bad night nationwide for Democrats / Progressives of all stripes, but California is still safe. Relatively.
+
+#### National and State
+
+Democrats ran the table for elected office, with Jerry Brown winning a record fourth term as California’s governor and Gavin Newsom keeping his position as Lieutenant Governor. Jackie Speier was re-elected to her Congressional seat.
+
+Kamala Harris retained her spot as California’s Attorney General for another four years, at which point she'll be in a terrific position to run for Governor (Jerry Brown will be termed out) or, if Barbara Boxer decides to run for Governor, Harris could run for California’s Class III Senate seat. Either way, Harris’ future looks very bright.
+
+(It will be interesting to see how the Newsom / Harris / Boxer negotiations work out for the two open offices in 2016.)
+
+#### State — Judicial
+
+State Supreme Court Associate Justices Werdegar, Liu and Cuéllar were confirmed for their appointments, as were all nine Appeals Court Justices. I voted against five of those nine. The vote counts for those [Appeals Court appointments](http://vote.sos.ca.gov/returns/courts-of-appeal/district/1/) are interesting; the YES and NO vote numbers are very, very similar for all nine. I suspect many people just voted straight down.
+
+#### Local
+
+Pulido, Knight and Lopez won seats on the [Ravenswood City School District](http://racetracker.shapethefuture.org/election_results.aspx?cID=152&eID=1). I voted for Pulido, Lopez and Valdez (fourth place in a three-seat race, by 183 votes), and am frankly shocked that Knight was elected, but as I don't have children (and wouldn't send them to school in this district in any case) it is ultimately of passing interest.
+
+Rutherford and Abrica were elected to the [East Palo Alto City Council](http://racetracker.shapethefuture.org/election_results.aspx?cID=156&eID=1). I voted for Rutherford and Carlton, who came in third in a two-seat race by 130 votes.
+
+David and Tucker won full-term seats on the [San Mateo County Harbor District](http://racetracker.shapethefuture.org/election_results.aspx?cID=164&eID=1) Board of Commissioners (I voted for David and Bernardo, who took third place in a two-seat race by 488 votes). Mattusch took the [short-term seat](http://racetracker.shapethefuture.org/election_results.aspx?cID=165&eID=1) on the same Board.
+
+#### [Statewide Ballot Measures](http://vote.sos.ca.gov/returns/ballot-measures/)
+
+Propositions 1 and 2 passed healthily; they were championed by Jerry Brown, who campaigned for them more vigorously than his own re-election (which was never in doubt).
+
+Prop. 45 failed, which I expect can probably be attributed to campaign fatigue. The “for” and “against” forces have been blanketing the airwaves for months and it was difficult to figure out what this measure was actually supposed to do. Given my general “no” bias on ballot measures, I’m not too upset; if this is something that the Insurance Commissioner decides needs to happen, it can be done legislatively.
+
+Prop. 46 also failed and I’m not sorry at all. The more I read about it, the worse it seemed, and the drug-testing of medical professionals provision appeared to be tacked on as a distraction from the real nastiness.
+
+Prop. 47 passed. I described my position above, so I’m pleased that this one went through.
+
+And Prop. 48 was defeated, by quite a large margin.
+
+#### Local Ballot Measures
+
+San Mateo County Community College District [Measure H](http://racetracker.shapethefuture.org/election_results.aspx?cID=173&eID=1) needed 55% and it got a healthy 65%. So it appears the Community Colleges will get the funding they asked for.
+
+The end. Until 2016.

--- a/src/content/elections/2016-11-06-2016-election-my-ballot.md
+++ b/src/content/elections/2016-11-06-2016-election-my-ballot.md
@@ -1,0 +1,93 @@
+---
+title: "2016 Election: My Ballot"
+date: 2016-11-06
+description: "Update: See the results/recap post."
+tags: ["elections", "politics"]
+mediumUrl: "https://medium.com/@smartwatermelon/2016-election-my-ballot-b8186c3f38e1"
+---
+
+### 2016 Election: My Ballot
+
+Update: [See the results/recap post](https://medium.com/@smartwatermelon/2016-election-results-4e8e395948b4#.xenem0soo).
+
+I do this every four years, at least; sometimes I get it done for the midterms as well. Line by line, candidate by candidate, measure by measure (by measure, by measure — because California), I figure out how I’m going to vote and write up the whys and wherefores.
+
+It seems like every time, we says it’s “the most important election ever” and once again, yes, it is the most important election ever. For obvious reasons.
+
+### Candidates
+
+**President and Vice President: Hillary Clinton and Tim Kaine.** Well, obviously. Unlike in previous elections where, if we’d ended up with John McCain or Mitt Romney, I would have been unhappy but the country would have survived, the Republican candidate in 2016 represents an existential threat to the continued health and welfare of the United States. [As Michelle Obama said](http://www.latimes.com/politics/la-na-pol-michelle-obama-speech-transcript-20161014-snap-story.html),
+
+> Either Hillary Clinton or her opponent will be elected president this year. And if you vote for someone other than Hillary, or if you don't vote at all, then you are helping to elect her opponent. And just think about how you will feel if that happens. Imagine waking up on November the 9th and looking into the eyes of your daughter or son, or looking into your own eyes as you stare into the mirror. Imagine how you'll feel if you stayed home, or if you didn't do everything possible to elect Hillary. We simply cannot let that happen. We cannot allow ourselves to be so disgusted that we just shut off the TV and walk away. And we can't just sit around wringing our hands.
+
+**United States Senator: Kamala D. Harris.** I’ve followed Kamala Harris’ career since she was at the District Attorney’s office in San Francisco. She’s highly competent, smart, capable, and a worthy successor to Barbara Boxer.
+
+**United States Representative, 14th Congressional District: Jackie Speier.** She’s served with distinction for some time and I have no reason to doubt she’ll continue to do so.
+
+**California State Senate, District 13: Jerry Hill.** I’m not interested in voting for a Republican candidate for the state senate.
+
+**Member of the State Assembly, 24th Assembly District: Marc Berman.** I don’t have a strong feeling one way or the other. Both are Democrats, both have presented reasonable arguments for their election, and both apparently have sufficient time and experience in government such that either would be a good choice. Based on the [Mercury News’ endorsement](http://www.mercurynews.com/2016/10/27/editorial-in-district-24-berman-still-the-better-choice/), I’ll pick Berman.
+
+**Judge of the Superior Court, Office №7: Sean Dabel.** There’s only one candidate listed. Being a judge seems like a pretty thankless job, so if Sean Dabel wants it (and is presumably qualified) I’m of a mind to let him have it.
+
+**Ravenswood City School District, Members, Governing Board (2): Marielena Gaona-Mendoza.** The local school district has been broken, corrupt, useless and worse-than useless for as long as I’ve lived in East Palo Alto. My only selection on this ballot is to vote out the incumbents.
+
+**City of East Palo Alto, Members, City Council (3): Carlos Romero, Lisa Yarbrough-Gauthier, Larry James Moody.** Four candidates, three of them incumbents, are running for three open seats. Quality of life has improved for the most part in EPA and I’m pretty satisfied with the course the current City Council has set, so I’ll vote to essentially keep the same crew in place.
+
+**San Mateo County Harbor District, Members, Board of Commissioners, Full Term (3):** I have no selection for this office.
+
+**San Mateo County Harbor District, Member, Board of Commissioners, Short Term:** I have no selection for this office.
+
+### Statewide Ballot Measures
+
+First, a word about my general principles with regard to ballot measures. I’m usually opposed to direct initiative lawmaking; I feel that legislating is (usually) best left to the Legislature. There are some cases where a ballot initiative is good or worthwhile enough to override that bias, but those tend to be few and far between. If I can’t decide how to vote on an initiative, I look at who is endorsing it and who’s against it, e.g. anything endorsed by the Jarvis foundation gets a no-vote from me. Also, as a homeowner who pays property taxes (where most bond payments come from), I’m generally opposed to bond measures.
+
+Information about state measures is, for some reason, not included on the voting guide from the San Mateo County registrar of voters, so I rely on [VotersEdge.org](http://votersedge.org/en/ca) to present the initiative text and arguments for and against.
+
+**Prop. 51 — Bonds for School Facilities: YES.** It’s a bond issue, which I’m generally against, but it’s a school upgrade/repair bond, which is an appropriate and justified use of funds. And the Jarvis foundation is against it, so I’m for it.
+
+**Prop. 52 — Private Hospital Fees for Medi-Cal: YES.** It seems fairly straightforward: continue and write into law the current practice of charging hospitals a fee to recoup state expenses in running the Medi-Cal program for low-income Californians. It’s not a bond measure; it’s supported by (shockingly!) both major political parties and the California Hospital Association. I am a bit leery of the promise that the funds may not be appropriated by the Legislature for any other purpose; this language appears in many initiatives but doesn’t actually seem to have any effect in practice. But I see no problems otherwise.
+
+**Prop. 53 — Public Vote on Revenue Bonds: NO.** I really don’t think this is a good idea, in line with my general principle of letting the Legislature do the legislating. It seems like if this passes, every single large-scale project will be subject to the kind of nasty political campaign we’ve seen for previous issues; can you imagine if BART improvements or every single segment of California High Speed Rail had to be approved statewide? And the Jarvis foundation is for it so I’m against it.
+
+**Prop. 54 — Changes to the Legislative Process: UNDECIDED.** I’m generally in favor of transparency in government, and this measure’s additional benefit of ending the practice of “gut and amend” is very tempting. There is an emergency clause, so that important time-sensitive legislation can be passed without the delay and review. But, I’m not comfortable being aligned with the groups supporting this measure. So on this one, I’m punting; I’ll do some more research and make a decision before the election.
+
+**Prop. 55 — Extend Tax on High Income: YES.** Though I’m somewhat swayed by the “respect the 2012 voters’ decision” to let this tax expire on schedule, I do believe that those who are fortunate enough to be in the higher-income classes ought to contribute a reasonable percentage to the public coffers. The usual array of groups are for and against this measure, so I’m coming down on a Yes vote for it.
+
+**Prop. 56 — Tobacco Tax: YES.** I’m anti-smoking, and if this measure causes people to quit because they simply can’t to buy cigarettes anymore, so much the better. The arguments about where the money collected actually goes don’t persuade me one way or the other, but I’m in favor of simply making smoking more expensive as a habit.
+
+**Prop. 57 — Parole, Sentencing and Court Procedures: YES.** The two parts to this measure are (a) make non-violent felons eligible for parole when they’ve served the minimum for their “main crime” (not the main plus any additional charges), and (b) put the decision whether to charge minors as adults in the hands of a court rather than a prosecutor. These both seem reasonable to me. I wish the change had come as a bill or regulation from the Legislature, but that’s the system we have.
+
+**Prop. 58 — English Language Education: YES.** I don’t have children, school-aged or otherwise, but I see no problem at all with children learning in the language with which they’re most comfortable (and receiving instruction in English at the same time, which is also part of the measure). The fact that there’s no budget impact makes this an easy Yes for me.
+
+**Prop. 59 — Political Spending Advisory Question: YES.** As an “Advisory Question,” this measure has no official, legal effect; it really just serves to make the Legislature aware of the sense of the electorate. And the sense of this particular member of the electorate is that the Supreme Court’s “Citizens United” decision was wrong, bad, and should be reversed.
+
+**Prop. 60 — Condoms in Adult Films: NO.** Existing law already regulates whether performers in adult films use condoms. This measure creates an unusual and potentially dangerous new right of action, allowing any private citizen to file a lawsuit and potentially recover damages against film producers.
+
+**Prop. 61 — Prescription Drug Costs: NO.** The ads for and against this one are mostly scare-factor, but in fact the measure as it’s written is just dumb. California is supposed to refuse to pay drug companies anything higher than what those companies are charging the VA. What happens if the drug company doesn’t accept California’s offered terms? The measure doesn’t say. What happens if the drug companies, lately shown to be run by mercenary creeps, just raise the price on everyone? The measure doesn’t say. I’m all for using market forces to keep drug prices down, but this is not the way.
+
+**Prop. 62 — Repealing the Death Penalty: YES.** A civilized society should not be killing its citizens, no matter what crimes they may have committed. The measure converts all existing death sentences to life-without-parole and makes that the maximum penalty the state can impose from now on. These people are never going to get out of prison, and realistically the twenty years of mandatory appeals on every death penalty case likely cost the state more than housing them for the rest of their lives.
+
+**Prop. 63 — Gun and Ammunition Sales: YES.** I don’t have a lot of sympathy for those who claim a Constitutional right from 1791, when the state of the art was a single-shot musket, applies equally to semi- and fully-automatic assault weapons with huge magazines of ammunition. Anything we can do to make it harder to get these weapons, magazines, and ammunition is something we should do and as soon as possible.
+
+**Prop. 64 — Making Recreational Marijuana Legal: YES.** Let’s see. Illegal: Grow operations wrecking protected wilderness areas; gang violence; heavy-handed law enforcement, often targeted to minority communities; and as a practical matter, with no regulation it’s likely the product is sub-par. Legal: grow operations in licensed, safe facilities; product is sold in licensed shops; taxes provide income for license and regulatory enforcement; regulated product has consistent quality. This is an obvious Yes and, as in the case of marriage equality, it’s embarrassing that California is once again following the crowd rather than leading the way.
+
+**Prop. 65 — Money from Carry-Out Bags: NO.** There are a pair of measures related to plastic bags, and they are written in such a way to be maximally confusing to someone trying to figure out which is better. And since they attempt to regulate the same thing, only one of the measures goes into effect if they both pass (the one with more votes). So what to do? Look at who is supporting each one. And tellingly, Prop 65 is supported by the plastic bag industry, while 67 is supported by environmental groups, the Democratic party, and even the major grocery stores.
+
+**Prop. 66 — Death Penalty Court Procedures: NO.** This is an opposing measure to Prop 62. It shortens the appeal process and, incredibly, removes from public oversight the methods the state uses to kill its prisoners. These are terrible proposals and should be opposed.
+
+**Prop. 67 — Plastic Bag Ban: YES.** See above, for Prop 65. This is the opposing measure, but it’s the one that actually puts the state’s existing plastic bag ban into effect, and it’s supported by groups with whom I agree.
+
+### San Mateo County/City of East Palo Alto Ballot Measures
+
+**Measure K: YES.** This extends a half-cent sales tax for another twenty years past its current expiration, essentially making it permanent. The tax revenues go into the county’s general fund. This is one of the ways government is funded. With this extension, lawmakers will have a reasonably sure source of funds for projects and expenditures.
+
+**Measure J: YES.** This measure improves and amends the East Palo Alto rent control ordinance, and the provisions were suggested by groups representing both tenants and landlords. I’m totally in favor of amending and updating existing law to align with changing conditions.
+
+**Measure O: YES.** It seems like this is something the East Palo Alto city council could have done legislatively, but I’m sure there’s some nuance that requires a ballot measure. The measure adds a tax and/or fee to landlords who rent at market-rate, while exempting those who rent to lower-income people. Its goals are to raise some money for the city’s general fund and to encourage landlords to generate housing for lower-income renters.
+
+**Measure P: YES.** This is a half-cent sales tax, like measure K above, but for transactions in the city of East Palo Alto. Same logic applies.
+
+This ballot is about as long as any I’ve seen, and really shows the problems with legislating by initiative. I expect many people won’t bother to take the time needed to read and understand all the ballot measures — I’m hearing that the San Francisco city ballot alone is equally as long as the statewide — and so will vote based on the measure title, or will skip voting entirely.
+
+I hope this was helpful in deciding your choices, or at least interesting reading. Or at least kept you occupied while we wait to see if the worst possible thing happens on Tuesday night.

--- a/src/content/elections/2016-11-21-2016-election-results.md
+++ b/src/content/elections/2016-11-21-2016-election-results.md
@@ -1,0 +1,79 @@
+---
+title: "2016 Election: Results"
+date: 2016-11-21
+description: "This is not a HOLY CRAP WHAT JUST HAPPENED post. This is not a HOW ARE WE GOING TO SURVIVE post. This is simply a recap of my 2016 Ballot…"
+tags: ["elections", "politics"]
+mediumUrl: "https://medium.com/@smartwatermelon/2016-election-results-4e8e395948b4"
+---
+
+### 2016 Election: Results
+
+This is not a HOLY CRAP WHAT JUST HAPPENED post. This is not a HOW ARE WE GOING TO SURVIVE post. This is simply a recap of my [2016 Ballot post](https://medium.com/@smartwatermelon/2016-election-my-ballot-b8186c3f38e1#.5bimn038q), with results and some commentary. For more post-election reaction, see the entire rest of the Internet.
+
+_Sources:_ [_California Secretary of State_](http://vote.sos.ca.gov/)_;_ [_San Mateo County Registrar of Voters_](https://www.shapethefuture.org/elections/results/2016/nov/web/)
+
+### Candidates
+
+**President and Vice-President:** ❌ Do I have to say it? I voted Clinton/Kaine. I’m frightened for our future. I intend to do whatever I can to resist and fight what comes out of Washington for the next four years.
+
+**United States Senator: Kamala Harris.** ✅
+
+**United States Representative, 14th Cong. District: Jackie Speier. ✅**
+
+**California State Senate, District 13: Jerry Hill. ✅**
+
+**Member of the State Assembly, 24th Assembly District: Marc Berman. ✅**
+
+**Judge of the Superior Court, Office №7: Sean Dabel. ✅**
+
+**Ravenswood City School District, Members, Governing Board: Marielena Gaona-Mendoza. ✅**
+
+**City of East Palo Alto, Members, City Council (3): Carlos Romero, Lisa Yarbrough-Gauthier, Larry James Moody.** ✅
+
+### Statewide Ballot Measures
+
+**Prop. 51 — Bonds for School Facilities: YES. ✅**
+
+**Prop. 52 — Private Hospital Fees for Medi-Cal: YES. ✅**
+
+**Prop. 53 — Public Vote on Revenue Bonds: NO.** ✅
+
+**Prop. 54 — Changes to the Legislative Process: YES.** ❌ I ended up voting NO on this because I couldn’t decide whether it was a good idea or not, and my general bias toward ballot initiative measures is negative. I guess we’ll have to wait and see how it’s applied in practice.
+
+**Prop. 55 — Extend Tax on High Income: YES. ✅**
+
+**Prop. 56 — Tobacco Tax: YES.** ✅
+
+**Prop. 57 — Parole, Sentencing and Court Procedures: YES.** ✅
+
+**Prop. 58 — English Language Education: YES. ✅**
+
+**Prop. 59 — Political Spending Advisory Question: YES. ✅**
+
+**Prop. 60 — Condoms in Adult Films: NO.** ✅
+
+**Prop. 61 — Prescription Drug Costs: YES.** ❌ Passed by the barest majority. Will it work? Will it be immediately enjoined, or the subject of multiple lawsuits? Who can say.
+
+**Prop. 62 — Repealing the Death Penalty: YES. ✅** I’m so proud of us, California. This was a good call.
+
+**Prop. 63 — Gun and Ammunition Sales: YES. ✅**
+
+**Prop. 64 — Making Recreational Marijuana Legal: YES.** ✅ See Prop 62, above.
+
+**Prop. 65 — Money from Carry-Out Bags: YES.** ❌ But see Prop 67 below.
+
+**Prop. 66 — Death Penalty Court Procedures: NO.** ✅
+
+**Prop. 67 — Plastic Bag Ban: YES. ✅** Both of the plastic bag measures passed (proving that many people didn’t bother reading or understanding what they were voting for) but 67 passed by over 35% while 65 barely scraped up 5.6%. I believe the rules for opposing measures state that if they both pass, the one with the greater margin prevails.
+
+### County / City Ballot Measures
+
+**Measure K: YES. ✅**
+
+**Measure J: YES. ✅**
+
+**Measure O: YES. ✅**
+
+**Measure P: YES. ✅**
+
+If not for the Presidential result, I’d be pretty happy with this election — at least from a California perspective. But we can’t ignore the top of the ticket, and it’s going to be very important to mobilize and be ready for 2018 / 2020. Get involved.

--- a/src/content/elections/2018-11-06-2018-election-my-ballot.md
+++ b/src/content/elections/2018-11-06-2018-election-my-ballot.md
@@ -1,0 +1,106 @@
+---
+title: "2018 Election: My Ballot"
+date: 2018-11-06
+description: "My choices, and some commentary, for the 2018 election."
+tags: ["elections", "politics"]
+mediumUrl: "https://medium.com/@smartwatermelon/2018-election-my-ballot-f1388d6c04c7"
+---
+
+### 2018 Election: My Ballot
+
+My choices, and some commentary, for the 2018 election. State of California / San Mateo County / City of East Palo Alto. I am a registered Democrat and _usually_ vote straight-ticket. But not always.
+
+![Go Vote California banner](https://cdn-images-1.medium.com/max/800/1*6lHWQRDQF6fyvAdkEp4jkA.jpeg)
+_Go Vote, California!_
+
+I am generally against most ballot measures, because I believe legislating should be done by the Legislature. I’m generally against most bond measures, because as a homeowner, they impact me directly — in the form of “extra” assessments on top of my property taxes — so the measure has to be really good for me to support it.
+
+When I am ambivalent or don’t have enough information about a candidate or ballot measure, I look at which groups or people have written supporting or opposing statements. If leaders of the Democratic party are in favor, I’m probably (but not always) in favor. If the Jarvis foundation is in favor, I’m probably against. I use the official Sample Ballot, and [KQED’s Voter’s Edge](http://votersedge.kqed.org/en/ca) voter guide.
+
+### Candidates
+
+**Governor: Gavin Newsom.** Newsom was the San Francisco Mayor who made early progress in issuing marriage licenses to same-sex couples. As Governor, he’ll represent California’s vigorous resistance against the current President. As for his opponent, I think we’ve had enough of the “businessman wants to run government like a business” theory. It doesn’t work.
+
+**Lieutenant Governor: Eleni Kounalakis.** Democrats Kounalakis and Hernandez seem equally well-qualified, but the former’s endorsements by President Obama and Senator Harris were enough for me.
+
+**Secretary of State: Alex Padilla.** This was an easy call. Republican Secretaries of State seem to exist mostly to stop people from voting, even when they themselves are on the ballot. While Republican candidate Mark Meuser is not currently in office, it’s important that he, or any Republican, not ever be in a position to affect California’s election laws and procedures.
+
+**Controller: Betty T. Yee.** Yee is the Democratic candidate in a statewide office opposed by a Republican candidate. In today’s political climate, I am not voting for _any_ Republicans.
+
+**Treasurer: Fiona Ma.**
+
+**Attorney General: Xavier Becerra.** Even if I weren’t certainly going to vote for Becerra as the Democratic candidate, Bailey’s [statements](http://votersedge.kqed.org/ca/en/ballot/election/73-6d5d7a/address/116%20mission%20dr/zip/94303/contests/contest/17130?date=2018-11-06) are completely disqualifying for potentially California’s chief law enforcement officer. For example:
+
+> Stop the continued dismantlement of California’s criminal justice and public safety institutions such as the ‘sanctuary state’ charade and the elimination of cash bail
+
+**Insurance Commissioner: Ricardo Lara.** Poizner has done a [creditable job](https://www.wikiwand.com/en/Steve_Poizner#/California_Insurance_Commissioner) in this role, but Lara has endorsements from Lt. Governor Newsom, Senator Harris, and current Insurance Commissioner Dave Jones.
+
+**Member, State Board of Equalization, 2nd District: Malia Cohen.**
+
+**United States Senator: Kevin de León.** Senator Feinstein has been a solid advocate and champion for California’s interests, for the most part, during her years of service in the Senate. However, I’m not at all comfortable with her record and positions since the 2016 election; she’s voted with the Republican majority rather than help reinforce the Democratic resistance on several occasions. It’s time for a fresh perspective and a strong commitment to resistance against the current administration.
+
+**U. S. Representative, 14th Congressional District: Jackie Speier.**
+
+**Member of the State Assembly, 24th Assembly District: Mark Berman.**
+
+**Associate Justices of the Supreme Court: Carol A. Corrigan and Leondra R. Kruger.** These are non-competitive offices for re-appointment; if these two sitting Justices are not retained, new Justices will be appointed. I have no reason to believe either of these Justices should not continue in their work. Both are endorsed by the Los Angeles Times.
+
+**Presiding Justice of Court of Appeal, District 1, Division 1: James M. Humes.**
+
+**Associate Justice of Court of Appeal, District 1, Division 1: Sandra Margulies.**
+
+**Associate Justices of Court of Appeal, District 1, Division 2: James A. Richman and Marla Miller.**
+
+**Presiding Justice of Court of Appeal, District 1, Division 3: Peter John Siggins.**
+
+**Associate Justices of Court of Appeal, District 1, Division 4: Jon B. Streeter and Alison M. Tucher.**
+
+**Presiding Justice of Court of Appeal, District 1, Division 5: Barbara Jones.**
+
+**Superintendent of Public Instruction: Tony K. Thurmond.** The advertising for this race is particularly bitter and, frankly, I don’t feel comfortable voting for either candidate. One (Thurmond) is endorsed by Senator Harris, the other (Tuck) is endorsed by President Obama’s Education Secretary. They both have impressive resumes, lists of organizational supporters, and near-identical statements of goals. I’ll go for Thurmond, but both campaigns should be ashamed of their behavior.
+
+**Ravenswood City School District, Members, Governing Board (3):** The local school district has been broken, corrupt, useless and worse-than useless for as long as I’ve lived in East Palo Alto. My only selection on this ballot is to vote out the incumbents, particularly Charlie Mae Knight.
+
+**City of East Palo Alto, Members, City Council (2):** Seven candidates, three of them incumbents, are running for two open seats. Quality of life has improved for the most part in EPA and I’m pretty satisfied with the course the current City Council has set.
+
+**Menlo Park Fire Protection District, Members, Board of Directors (3):** I have no selection for this office.
+
+**Midpeninsula Regional Open Space District, Member, Board of Directors, Ward 5: Greg Scharff.**
+
+**San Mateo County Harbor District, Members, Board of Commissioners (2):** I have no selection for this office.
+
+**San Mateo County Board of Education, Member, Trustee Area 1:** I have no selection for this office.
+
+### Statewide Ballot Measures
+
+See above for my general feelings about ballot measures.
+
+**Prop. 1 — Affordable Housing Bonds: YES.** California suffers from a well-documented housing shortage, especially for those on the lower end of the income spectrum. This ballot measure authorizes bonds to pay for affordable multifamily housing, down payment assistance, infrastructure, and farmworker housing, plus $1 billion in home loans to eligible veterans.
+
+**Prop. 2 — Mental Health Housing Program: YES.** This seems like an accounting measure at its heart. Authorizing the use of Prop 63 funds to pay for bonds to build housing for mental health housing. No budget impact.
+
+**Prop. 3 — Water Bonds: NO.** Seems like this is on the ballot every other election. I would like to see efficient use of the funds already allocated before approving more.
+
+**Prop. 4 — Children’s Hospital Bonds: YES.** This continues an existing, successful program to rebuild and improve the state’s children’s hospitals.
+
+**Prop. 5 — Property Tax Rules: NO.** California’s property tax system is broken and this isn’t the way to fix it. Instead, Prop. 13 should be amended to exclude commercial/industrial property.
+
+**Prop. 6 — Transportation Taxes and Fees: NO.** This subversive measure is written so that voting NO actually means YES, keep an existing fuel tax and registration fee, all of which goes to state transportation projects; but a YES vote means NO, cancel this tax and fee, thus yanking funding from projects already in progress and canceling vital work planned to start soon.
+
+**Prop. 7 — Daylight Saving Time: YES.** It allows the Legislature to vote to make changes to the state’s implementation of DST rules. California’s system of ballot measures means that because this was decided by popular vote (in 1949), the voters must approve changes. The measure doesn’t make any immediate change; it just returns legislative control over this issue to the Legislature.
+
+**Prop. 8 — Kidney Dialysis Clinics: NO.** This seems to be a measure in search of a problem. Any changes to California’s enforcement of insurance premiums or prices charged to dialysis patients would seem to be regulated by the Insurance Commissioner and the Legislature. It’s not a fit subject for a popular ballot measure.
+
+**Prop. 10 — Local Government and Rent Control: NO.** This measure would repeal the Costa-Hawkins Rental Housing Act, by popular ballot instead of by legislative action. This issue should be addressed by the Legislature. If individual legislators are not willing to take up the matter, they can be voted out.
+
+**Prop. 11 — Ambulance Employee Breaks: YES.** This seems reasonable and puts ambulance employees on par with most other classes of employees; if you’re subject to being called in to work while on a break, you are at the pleasure of your employer and should be paid for your time.
+
+**Prop. 12 — Farm Animal Cages: YES.** This clarifies and expands on a 2008 ballot initiative which established minimum standards for caging farm animals. Prop. 12 further codifies those standards.
+
+### County of San Mateo / City of East Palo Alto Ballot Measures
+
+**Measure HH: YES.** This is a City of East Palo Alto parcel tax on commercial properties, with funds allocated to affordable housing and science education programs. East Palo Alto is experiencing a business boom, with many new office buildings and recognizable tenants. I find it reasonable that the city and its residents should realize some small amount of this new prosperity.
+
+**Measure W: YES.** San Mateo County certainly needs to continue to maintain its highways, improve and increase its transit systems, and enhance bike and pedestrian safety. This is a half-cent sales tax which is dedicated to these projects. The measure language includes the usual caveat that “the state cannot take these funds” but somehow the state usually manages to do so anyway. Still, the projects need to happen and this is how they are funded.
+
+For a mid-term ballot, this one is extensive — perhaps excessive — and continues to show the problem with legislating by popular initiative. If you don’t have time to read up on all the issues, and I don’t blame you, at least please take the time to vote for a slate of candidates who will oppose and resist the current presidential administration.

--- a/src/content/elections/2020-10-11-2020-general-election-my-ballot.md
+++ b/src/content/elections/2020-10-11-2020-general-election-my-ballot.md
@@ -1,0 +1,53 @@
+---
+title: "2020 General Election: My Ballot"
+date: 2020-10-11
+description: "My ballot choices for the 2020 General Election."
+tags: ["elections", "politics"]
+mediumUrl: "https://medium.com/@smartwatermelon/2020-general-election-my-ballot-600ba38f0c26"
+---
+
+### 2020 General Election: My Ballot
+
+My ballot choices for the 2020 General Election.
+
+I live and vote in the City of East Palo Alto, which is in San Mateo County; in the 24th State Assembly District, the 13th State Senate District, and the 14th U.S. Congressional District. I’m listing my ballot choices for these offices, as well as the twelve(!) ballot propositions.
+
+![2020 General Election ballot header](https://cdn-images-1.medium.com/max/800/1*ET4dEZ3eZ4BZjGZxXLxEKQ.png)
+
+I am a registered Democrat and generally progressive in my political and social beliefs. I’ve made my decisions based on information from the Official Voter Information Guide, General Election Sample Ballot, and [Voter’s Edge](https://votersedge.org/en/ca).
+
+**President and Vice President:** Joe Biden and Kamala Harris
+
+**U.S. Representative, 14th Congressional District:** Jackie Speier
+
+**State Senator, 13th Senate District:** Josh Becker
+
+**Member of the State Assembly, 24th Assembly District:** Marc Berman
+
+**Proposition 14 — Stem Cell Research:** No
+
+**Proposition 15 — Taxes on Commercial Property:** Yes
+
+**Proposition 16 — Allow Public Agencies to Consider Diversity:** Yes
+
+**Proposition 17 — Voting Rights for People on Parole:** Yes
+
+**Proposition 18 — Voting Rights for 17-Year-Olds:** Yes
+
+**Proposition 19 — Changes in Property Tax Rules:** Yes
+
+**Proposition 20 — Changes to Criminal Penalties and Parole:** No
+
+**Proposition 21 — Rent Control:** Yes
+
+**Proposition 22 — Rideshare and Delivery Drivers:** No
+
+**Proposition 23 — Kidney Dialysis:** Yes
+
+**Proposition 24 — Consumer Privacy:** No
+
+**Proposition 25 — Yes or No on Getting Rid of Bail:** Yes
+
+**City of East Palo Alto Measure V — Transient Occupancy Tax:** Yes
+
+**Peninsula Corridor Joint Powers Board Measure RR — Caltrain service:** Yes

--- a/src/content/ouatrevisit/2022-11-10-ouatrevisit-s4e2223.md
+++ b/src/content/ouatrevisit/2022-11-10-ouatrevisit-s4e2223.md
@@ -1,0 +1,137 @@
+---
+title: "#OUaTrevisit S4:E22/23"
+date: 2022-11-10
+description: "It’s a Wednesday and that means it’s time for another #OUaTrevisit! This week: Season 4, episodes 21 and 22."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s4-e22-23-3ab5d827de81"
+---
+
+### #OUaTrevisit S4:E21/22
+
+> Note: For various reasons, I’m publishing my revisit writeup as a Medium post (and tweeting a link) instead of a Twitter thread. Please also read [Cindy’s](https://twitter.com/cstephens2) and [Katie’s](https://twitter.com/metzger_katie) write-ups.
+
+It’s a Wednesday on the Internet and that means it’s time for another [#OUaTrevisit](https://twitter.com/search?q=%23OUaTrevisit&src=typed_query&f=live)! Cindy and Katie and I are working our way through the seven-season ABC fantasy/adventure/melodrama/soap opera Once Upon A Time, two episodes per week, until we finish the series or somebody pays us to stop.
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*MQxABjZDj1qDRRt8tJh77w.gif)
+
+**S4:E21 Mother**  
+“Regina remains suspicious of her mother’s intentions.”  
+Air date: May 3, 2015
+
+- Hey, it’s [dad](https://onceuponatime.fandom.com/wiki/Prince_Henry_%28The_Thing_You_Love_Most%29), hi dad.
+- In case we’d forgotten about Regina’s previous dark deeds, this is a reminder. Doesn’t hesitate to murder.
+- Cora’s back? Wasn’t she [banished](https://onceuponatime.fandom.com/wiki/We_Are_Both#Recap)?
+- Pretty sure I know which [Gastown bar](https://g.page/TheLamplighterGastown?share) Robin and Regina are at.
+- I don’t remember Zelena being responsible for Neal’s death.
+- We’re all going back to Storybrooke!
+- Maybe don’t tempt this guy into finding a way to kill you.
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*ImmfA1xHLAb3CVnqIYB3DA.gif)
+
+- Finally, we get an explanation of why Gold needs Emma to turn dark. The ink!
+- They totally just skipped out on the check.
+- Emma is still not ready to deal with her parents.
+- “I borrowed a rabbit.”
+- Regina’s necklace is a giant spider.
+- Huh. We know this won’t work because it didn’t work.
+- That hall always seems to need mopping.
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*9x6TQKAdjMb_k0HrTaDYNw.gif)
+
+- Oof, Gold is not in a good way.
+- That implies the Dark One is a separate entity, rather than a mantle. Interesting.
+- Hello, Sheriff.
+- Dennis Moore, Dennis Moore.
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*Zle9g6omnDEkj9bFRIiDCQ.gif)
+
+- This scene with the Author and Regina is really something. She’s his “favorite character to write for”. He literally creates reality. And they’re just chatting.
+- They don’t need Emma to go dark because they now have Lily!
+- Maleficent actually making sense here. But Lily isn’t having any.
+- “I don’t need grooming advice from Annie Hall.” 🔥
+- “I’m not here to kill you.” “Okay…”
+- Snow/Charming really owe her.
+- “Dark Star Pharmacy”
+- Regina’s first outfit in this scene: 100%
+- Regina’s second outfit in this scene: not so much
+- Uh, that’s not Robin. Damn, Cora.
+- Maybe don’t talk like that to the extremely powerful Evil Queen, bro.
+- Hah, she saw right through it.
+- Regina could have asked.
+- Oops, Lily in Storybrooke is going to have magic. And she’s Maleficent’s daughter. 🐉
+- Maybe not-Evil Regina is going a little too hard on Zelena.
+- “I like when people find their good hearts along the way.”
+- I guess Maleficent probably can’t be hurt by Lily’s dragon fire. But I’m surprised she didn’t change.
+- Oh dang, nice healing work, Emma.
+- I’m here for sympathetic Maleficent, frankly. It works with Angelina Jolie and it works with [KBvS](https://www.imdb.com/name/nm0061877/).
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*_4HOxqVru5oTzePUbcf4sQ.gif)
+
+- Writing Zelena out of the story this way is kind of brutal.
+- 🎵 Part of that world 🎵
+- Monologuing in front of the Author was kind of dumb, frankly.
+- “Heroes and Villains”, is that from 5E?
+
+![Screenshot from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*tdWh-OtWKN6JEq_RgNewuA.jpeg)
+
+**S4:E22 Operation Mongoose Part 1  
+**“Henry steps up to save his family.”  
+Air date: May 10, 2015  
+Note: Part 2 aired on the same date.
+
+- That TV!
+- I love everything about this scene. The old ABC logo. The decor. “Does it have a clicker?”
+
+![Screenshot from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*yOFPb88cCTQqSYOaOLtpNA.jpeg)
+
+- The senior salesman is not too pleased with Isaac.
+- Star Publishing. Who might this be? Empty room with just a desk.
+- Oh, it’s the Apprentice! This is Isaac becoming the Author.
+- “I’m more of an IBM Selectric kind of guy.”
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*gC1NGp7QRdWibxKe7Ga3EQ.gif)
+
+- I actually have that engraved metal ballpoint pen.
+- “Come with me if you want to write.” 🤖
+- August!
+- How did they get the magical hat device back?
+- Henry has grown a bit.
+- Room service and indoor plumbing, exactly.
+- So, not your memories at all.
+- Blue PeeChee folders in Henry’s backpack.
+- Changing that bit of Gold’s story is going to have butterfly effects, I think?
+- Tinkerbell wind vane!
+- Right, Henry can leave town.
+- Very majestic cover photo.
+- Now I wonder where this building is.
+- “Don’t write your own happy ending.”
+- I was not expecting that. Henry inserted himself into the new story.
+- How did the Author get trapped as well?
+- Ogres, I’ve got an Ogre Slaying Knife, It’s got a +9 Against Ogres!
+
+![Screenshot from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*QLvAdDJNVOCLB-H8Wio1zQ.jpeg)
+
+- Robert Carlyle really playing up the knight in shining armor.
+- Regina in the Snow outfit!
+- Medieval Regina doesn’t blink an eye at a bound, printed book.
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*EeOcXPXILAHzQClTQWmRBQ.gif)
+
+- Who is the Queen in this scenario? Snow? That’s hardly a sad villain ending for her.
+- The Black Dwarfs. I love these guys. “Heigh-ho, boys, it’s off to work we go.”
+- Evil Snow’s outfit and her hair are 🔥
+- Heart walkie-talkie mode.
+- The dark makeup on Snow and David is great.
+- Isn’t he interfering in his own story now?
+
+![Screenshot from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*Eh5ODkU3cujwuIOBx8KWjg.jpeg)
+
+- This story reversal is so good.
+- She didn’t know Robin. Interesting.
+- Here’s the thing: I believe Regina in this role more than Snow. Maybe Lana is just a better actor.
+- Aahhh Zelena is the bride!
+- Same tavern, right?
+- Where is Emma, anyway?
+- She’s in Rapunzel’s tower… And she’s insane.
+
+![Screenshot from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*7k6xgWc-g31Uf_NFRQZTPw.jpeg)

--- a/src/content/ouatrevisit/2022-11-17-ouatrevisit-s4e23.md
+++ b/src/content/ouatrevisit/2022-11-17-ouatrevisit-s4e23.md
@@ -1,0 +1,99 @@
+---
+title: "#OUaTrevisit S4:E23"
+date: 2022-11-17
+description: "Season 4 finale! Make sure to read @cstephens2 and @metzger_katie’s write-ups too."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s4-e23-ecd8cc2f42"
+---
+
+### #OUaTrevisit S4:E23
+
+> Note: For various reasons, I’m publishing my revisit writeup as a Medium post (and tweeting a link) instead of a Twitter thread. Please also read [Cindy’s](https://twitter.com/cstephens2) and [Katie’s](https://twitter.com/metzger_katie) write-ups.
+
+Well, #OUaTrevisit friends, we’ve come to the end of [Season 4](https://en.wikipedia.org/wiki/Once_Upon_a_Time_%28season_4%29), and because there were an odd number of episodes this season, we’re only revisiting one episode this week — the season finale. Next week, we’ll kick off [Season 5](https://en.wikipedia.org/wiki/Once_Upon_a_Time_%28season_5%29), which (if my math and calendar skills are up to snuff) we should wrap up on February 8th. And after _that,_ we’ll be taking a four-week hiatus before launching into the final two seasons.
+
+> Q: Why are you doing this on Medium now instead of a Twitter thread?
+
+I mean, have you seen Twitter lately? It’s possible and even probable that Twitter won’t be around for much longer — certainly not as a platform that’s reliable, widely accessible, and safe. I’m migrating most of my social presence to [Mastodon](https://worldkey.io/@smartwatermelon), and while I’m not one to evangelize, it’s pretty nice in a sort of late-2000s/early-2010s era Twitter “friendly people talking to each other” vibe.
+
+But enough of this frivolity. Let’s get on with this week’s Revisit!
+
+**Season 4, Episode 23: Operation Mongoose Part 2**  
+“Henry steps up to save his family.”  
+Air date: May 10, 2015  
+Note: Parts 1 and 2 aired on the same day.
+
+- Locking up the Savior and then chaining her to the floor is extra cruel.
+- Important to note that Regina is specifically recast as a hero in this reality, and for Regina stans (like me), it’s glorious.
+- For Rumple, the “right” choice is the wrong choice.
+- “Without an invitation from the captain” but who is the captain? It’s Blackbeard!
+- The Black Knight always triumphs.
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*948zgEz6svkOe4hqF0J5pg.gif)
+
+- Prisoner transfer from cellblock 1138… or the kingdom of Kashyyyk.
+- Emma didn’t lose her memories.
+- Aww, cute. Killian and Emma are re-meeting.
+- Oh, a guard dragon!
+- Chain shot?
+- Wow. Good shot.
+- Meanwhile, at the Small Council…
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*z01aKa7qS_HUSbbI7Ki8EA.gif)
+
+- Evil Granny!
+- I feel like a dwarf is about to get the Untouchables treatment here.
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*CH5xoVzzCvg2-rj0Kq9H4w.gif)
+
+- “You’re a regular Jack Sparrow,” says Emma, cranking up the Synergy Machine.
+- “You’re the one who’s hard to recognize” in that creepy dark makeup.
+- Emma and Henry just standing there watching Killian sacrifice himself.
+- Rumple is, wait for it, lying to Belle.
+- Chip!
+- Ugh, vulnerable Regina is the best.
+- Ah, the classic “disrupt the wedding” gambit.
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*gqTeIiBeNGdRgm2O4AZmtQ.gif)
+
+- Uh, what if Robin isn’t into Regina in this reality?
+- Oh hello, hero/villain Rumple.
+- Huh, I did not see that coming. Seems bad.
+- Ooh someone is turning green!
+- Go, Emma! 👊🏻
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*J7B-Tf4zpEISM1s-5FW2tA.gif)
+
+- Henry is now the Author?!
+- And just like that, it never happened. But they all remember it.
+- 🙄
+- Good thing it wasn’t like the Matrix, right? If you die in the renegade Author’s fanfic, you don’t die in real life.
+- Oh, Emma. Sheesh. Just tell him!
+- Is there a problem, Officer?
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*uyCVAX0oXYxVJYz_aWLxRA.gif)
+
+- I mean a bad boss can fuck you up for a long time.
+- The stories can never be erased, but I guess they can be modified.
+- “With great power,” etc.
+- Huh. He broke the quill, so what does that mean? Not an author after all? Does the power lie in the quill or in the wielder?
+- When Rumple’s heart goes totally dark, what happens? All Dark One, all the time?
+- Yay!
+- Zelena is locked up. What about Lily?
+- Nice to see Emma and the parents patching it up.
+- “It’s a dragon thing.” And I really hope Lily doesn’t villain out.
+
+![Screenshot from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*qyiUjsORLM9cfF1QsNTyBw.jpeg)
+
+- Oh good, there’s still a magical box. And the Apprentice has heart-ripping power.
+- Wow. Is the Dark One power now banished to the hat forever?
+- Oh, dear. This seems bad. Dark One power just flying around town.
+- So actually it wasn’t a great idea to untether the power from the dagger. Nice job, Apprentice.
+- Merlin??
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*vmMuokQrKCY1-_pA72-Zew.gif)
+
+- Oh no… At least she finally told him.
+- Emma Swan, Dark One. Does she get new business cards?
+
+![Reaction GIF from Once Upon a Time Season 4 recap](https://cdn-images-1.medium.com/max/800/1*HLclifo7PAbnnaU3ag_7Gw.gif)

--- a/src/content/ouatrevisit/2022-11-23-ouatrevisit-s5e12.md
+++ b/src/content/ouatrevisit/2022-11-23-ouatrevisit-s5e12.md
@@ -1,0 +1,142 @@
+---
+title: "#OUaTrevisit: S5:E1/2"
+date: 2022-11-23
+description: "It’s Wednesday and time for the weekly Once Upon a Time revisit! Now on Medium, Mastodon, and many other places around the internet."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e1-2-47c31e8b6fd3"
+---
+
+### #OUaTrevisit: S5:E1/2
+
+> Note: I am no longer active on Twitter, and have turned off auto-posting to Twitter from Medium. You’ll see a link to this post on [Mastodon](https://worldkey.io/@smartwatermelon) and potentially in other places as I reassess my social media presence.  
+> You can find my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts on their respective platforms.
+
+Good day, and welcome to Season Five! As you may recall, when we left our heroes in the midst of a cliffhanger, Emma absorbed the Dark One’s miasmic power to keep it from flowing into Regina. Cliffhanger!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*pdF1Ne6H-yO5U3Hrvii7Hw.gif)
+
+#### S5:E1 Dark Swan
+
+“The heroes band together to save Emma.”  
+Airdate: September 27, 2015
+
+- The Sword in the Stone!
+- Young Emma casually steals a giant candy bar. Was that a Wonka Bar?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*7QvQWHKybOaEvOVj4_2yqg.gif)
+
+- Who is this guy? I don’t need chatty ushers when I’m trying to watch a movie.
+- “Leave the Sword alone”? Was he talking about the Dark One’s dagger?
+- Either the hills are alive, or they’re [taking the Hobbits](https://www.youtube.com/watch?v=uE-1RPDqJAY) [to Isengard](https://www.youtube.com/watch?v=tn_GKGN0Dh8).
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*P8naX97a7dDzRsxte2weBw.gif)
+
+- He chose… poorly.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*a8PBnRy3lg9FuGSubW5vmg.gif)
+
+- Remember when you could do this at Disneyland?
+- Omg, the sword is broken and the tip is clearly the Dark dagger!
+- “Guyliner”!
+- Armus? Somebody tell Tasha to get behind a rock.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*Io7eeHT1eIW9U4yNx8kg-A.gif)
+
+- I love Carlyle as Rumple as the power of the Dark One in Emma’s head.
+- Huh, the Apprentice didn’t die.
+- “She is now where all darkness is born. In your realm.” Meaning the Enchanted Forest?
+- Oh no not Light Magic again.
+- Wicked, eh? Wonder who they’ll get.
+- Don’t make Emma angry, you wouldn’t like her when she’s angry.
+- Hmm, this seems familiar. 🥀
+- It’s a wisp. Where’s Merida?
+- “I am powerless,” says the least trustworthy person in this scene.
+- Oh, I wasn’t actually expecting Merida.
+- This is a terrible idea, Killian.
+- “You need a hobby to take your mind off the terrible things you’re going to do. Have you tried knitting?
+- Aren’t you a little short for a stormtrooper?
+- Wow, that’s one way of removing the cuff. 👋🏻
+- Do we believe Zelena when she says she just wants to leave? Still, we need the wand to save Emma.
+- That was a pretty risky plan.
+- She left her cloak!
+- “Accent’s a bit much, no?” says the imitable Robert Carlyle.
+- So we’re letting Granny’s diner get sucked up by the twister?
+- Grumpy announcement! 🍻
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*q06VvWePi8UU9r-XvjT5qQ.gif)
+
+- Dark Rumple with some real Emperor Palpatine vibes here.
+- Whoa, Emma, really? 🍅
+- Not a way to make an ally but at least she didn’t kill her.
+- The actress playing Merida (Amy Manson) plays Maladie in The Nevers.
+- There better be some stockinged feet under the porch.
+- Camelot!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*plNfInOLQALjQodv00UNuw.gif)
+
+- Where’s Tink though?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*RAp2PhZlDspqGbHWSR8b9Q.gif)
+
+- Six weeks later! Everyone is back and wearing amazing clothes!
+- Based on her new outfit, Emma watched Dark City while she was away.
+- Regina’s dress. ❤️❤️❤️
+
+#### S5:E2 The Price
+
+“There is no cheating the price of magic.”  
+Airdate: October 4, 2015
+
+- (Dearie)
+- Poor Sneezy?
+- Another new curse??
+- Snow Queen, Pan, Trio of Terror!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*dOLWkbXSlEQuw_XraA7f8Q.gif)
+
+- I’ve been turned into a tree, can I go now?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*11xSVp9ptyVF_mjc5gol2Q.gif)
+
+- Merlin is also a tree. Just like Amberle.
+- Regina is the Savior, sure.
+- “It’s far easier to hate a Dark One than to love one.”
+- Dark Emma sneers just so perfectly.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*ov-DCoAufsHNtuaS4cTRJg.gif)
+
+- What is Dark Emma’s motivation here?
+- Wait, MM and Charming lied? But that never happens.
+- “Arthur, you’re with me.” Just ordering the king around.
+- They went to Storybrooke REI.
+- “Tree demon!” — Leroy
+- Interesting lock on that door. Wonder what that’s about.
+- “You want to do this the hard way? Good, because I love the hard way.”
+- Dang. That’s a big jewel.
+- Snow and Charming are perfectly at home in medieval clothes.
+- Of course, Regina went for the Evil Queen dress.
+- A spying gem! That always goes well.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*SSDHqou55drizU8qicXJgg.gif)
+
+- The tree demon is a Fury sent to collect on a magical credit card?
+- Belle is wearing a pretty dress for once!
+- “Gramps”
+- Henry has an iPod. Remember iPods?
+- Henry!! You are not playing “Only You” for your crush!! Winning.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*aTSPwxQTr8oZfLap-CKVVA.gif)
+
+- Eek, Robin got stabbed. But we know he lives, so, okay.
+- Is any magic performed by Emma automatically dark magic?
+- So that was Emma volunteering, not charging a price. Huh.
+- The CG budget went up this season!
+- Just like on Xandar.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*_IgCZCKrqjWN9C1qMQLQ3A.gif)
+
+- I see the diner has been fully restored.
+- This is so perfect. I just can’t. Henry is playing [Yazoo](https://www.youtube.com/watch?v=a4g5MeonGYM) for his crush.
+- “Who you were doesn’t matter. What matters is who you are.”
+- Thanks for fixing Sneezy, Regina.
+- “Renewed shall be blade that was broken: The crownless again shall be king.”

--- a/src/content/ouatrevisit/2022-11-29-ouatrevisit-s5e34.md
+++ b/src/content/ouatrevisit/2022-11-29-ouatrevisit-s5e34.md
@@ -1,0 +1,136 @@
+---
+title: "#OUaTrevisit: S5:E3/4"
+date: 2022-11-29
+description: "It’s Wednesday in Camelot and that means it’s time for another Once Upon A Time Revisit (#OUaTrevisit) with Katie and Cindy and me."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e3-4-6e809012466d"
+---
+
+### #OUaTrevisit: S5:E3/4
+
+> Note: As previously mentioned, this will now be the canonical home of my #OUaTrevisit posts. I’ll continue posting these to [my Mastodon account](https://worldkey.io/@smartwatermelon), and linking to my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts on their respective platforms.
+
+Greetings, worthy Knights! It’s Wednesday in Camelot and that means it’s time for another Once Upon A Time Revisit (#OUaTrevisit) with Katie and Cindy and me. We originally started this on Twitter, but, well, you know.
+
+This week, we’re on to season five, episodes three and four. In one parallel storyline, our heroes are in Camelot, trying to get Merlin out of a tree (?) to get him to remove the Dark One’s magic from Emma. Or something like that. In the other storyline, we’re back in Storybrooke, six weeks later, and everyone has lost their recent memories (again).
+
+#### S5:E3 Siege Perilous
+
+“David and Arthur embark on a heroic quest.”  
+Airdate: October 11, 2015
+
+- “an heroic” surely?
+- Dwarfs whistling!
+- What does Dark Emma want with Happy’s axe?
+- Emma could wiggle her nose!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*uT-wefpRddorNMSTIHkXPQ.gif)
+
+- “Madame Savior”
+- Oh good, the Forest of Eternal Night.
+- Great, these two will get on super well I’m sure.
+- “Dwarfs are your department”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*BCSNQD2DZSIAKwGsfDZ_Yw.gif)
+
+- Yes, David, you’re pointless.
+- Reliquary, the new alternative social network.
+- Who could the hero be?
+- Zelena, mute-singing like a mermaid.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*uF2BPagXYheJ_SwvX9XP2A.gif)
+
+- Good Regina is really throwing the evil around with Zelena.
+- I’m naming my office chair the Siege Perilous.
+- Most of the stuff is gone. This guy obviously did it.
+- “I know how to use a phone, Hook.”
+- Killian’s simple love life with the Dark Swan, who calls in to-go orders. What was that call like? Did she DoorDash it? Does Uber Eats even deliver to Storybrooke?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*i55CHXALDpwtI0GIQjjHgQ.gif)
+
+- Grilled cheese sandwiches, onion rings, breadsticks, and wine. The Dark Swan isn’t into protein or veggies.
+- Oh good an archery tournament.
+- That’s the bridge on Tom Sawyer’s Island.
+- Next question: what lives in the swamp?
+- Right, someone’s gonna come in to pawn a magic bean.
+- “Doc-tober Fest”
+- As expected, it was Grif.
+- Arthur can drive?
+- I hope David brought a bag of sand.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*xz_4p6_1zmYZ6tuXrImjuQ.gif)
+
+- Going straight for the hard questions.
+- Dark Emma and Killian? Sure, why not.
+- It’s gonna take days to dry out that armor.
+- Did Arthur pick David’s pocket?
+- (thunk)
+- Badger badger badger mushroom mushroom
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*qyMUnXidDVXR0SHZFaOK4w.gif)
+
+- Wow, that’s a lot of bling on David.
+- Arthur trusts David, but David is lying to Arthur (about the identity of the Savior). Typical.
+- I bet they have a falling out in the missing time.
+- Arthur is a villain?
+- Ah, Arthur did get the mushroom from David.
+- Oof. Grif’s gonna die.
+- Poison from Agrabah!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*psqJI_WL3u9RaYd03tNvQw.gif)
+
+- It didn’t just kill him, it disappeared him.
+- Granny’s still gonna charge you for the plate.
+- Gold is going to be the hero?!
+
+#### S5:E4 Broken Kingdom
+
+“King Arthur may be hiding his true intentions.”  
+Airdate: October 18, 2015
+
+- MAY be? Eh, I’m sure it’s fine. (RIP Grif)
+- Tween Arthur is coming on pretty strong.
+- What will you tell the people? He’ll lie to them, just like everyone else lies on this show.
+- (It’s only a model) (shh)
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*6KLzjlA63X6rsBL7aDin_w.gif)
+
+- David’s like “oh yeah I’ve seen that…around…”
+- The dreamcatchers aren’t going to be enough to stop the dark powers, unfortunately.
+- Or they could just not have a council in her room.
+- Regina’s look in this scene!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*9FL5sHVrcxAMrnLfwRc7ww.gif)
+
+- MM is taking David apart and it’s about time.
+- ⭐️👁🌞
+- Arthur is so typical.
+- Oh brother, David, you pick NOW to finally be honest?
+- Won’t it find Guin’s biggest weakness though? How did she tell the gauntlet to focus on Arthur?
+- Oil, that is. Black gold. Texas tea.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*9qaqNN_EQCzUKjvqSIGuDA.gif)
+
+- (It’s only a green screen) (shh)
+- David is once again doing the wrong thing. But MM outwitted him. (not difficult)
+- In a stable?
+- “I hope you’re ready to get your heart racing”
+- Fairly personal question, MM.
+- That’s a portal. To where? Looks like Wonderland.
+- “Assuming that’s still what you want…”
+- How many Emmys did Carlyle win for this performance? All of them, I hope.
+- The sand “fixes” anything? Even broken relationships?
+- The kingdom doesn’t even exist, wow.
+- “She’s not coming.” I can’t adequately convey Ginnifer Goodwin’s perfect tone of voice from that line.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*5FIKMLQO1qcHXjumMp4dVg.gif)
+
+- What is Killian’s plan though?
+- “A blade that can stand up to Granny’s meatloaf.”
+- Guinevere of course is still under the spell of the sand.
+- Merida!
+- Shouldn’t Regina see that David and MM are under a spell?
+- Poppies will put them to sleep.
+- “I need you to make him Brave, which is also the title of the movie in theaters now, please go see it.”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*ADGcqedGyfntPbMEtoCRxg.gif)

--- a/src/content/ouatrevisit/2022-12-08-ouatrevisit-s5e56.md
+++ b/src/content/ouatrevisit/2022-12-08-ouatrevisit-s5e56.md
@@ -1,0 +1,135 @@
+---
+title: "#OUaTrevisit: S5:E5/6"
+date: 2022-12-08
+description: "What with one thing and another, we postponed the usual Wednesday-night #OUaTrevisit to Thursday for this week, and now we’re on to…"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e5-6-c0b4b354a860"
+---
+
+### #OUaTrevisit: S5:E5/6
+
+> Note: As previously mentioned, this will now be the canonical home of my #OUaTrevisit posts. I’ll continue posting these to [my Mastodon account](https://worldkey.io/@smartwatermelon), and linking to my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts on their respective platforms.
+
+Hello and Happy W̶e̶d̶n̶e̶s̶d̶a̶y̶Thursday, OUaT fans! What with one thing and another, we postponed the usual Wednesday-night #OUaTrevisit to Thursday for this week, and now we’re on to the fifth and sixth episodes of season five.
+
+#### S5:E5 Dreamcatcher
+
+“Emma and Regina form a plan to free Merlin.”  
+Airdate: October 25, 2015
+
+- That’s Merlin! And it was Merlin in the movie theater with young Emma.
+- If you were a tree, what kind of tree would you be?
+- MM and David are ensorcelled, remember. Arthur is controlling them.
+- Once you start down the dark path, forever will it dominate your destiny.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*JDq_0G9J73w97h-SMlFwvA.gif)
+
+- Rumple is missing, presumed fed.
+- Emma says she’s stronger as the Dark One than Rumple. I believe it.
+- Not sure about Dark Emma’s cape/train/skirt thing.
+- Dreamcatchers are considered dark magic?
+- Sometimes spells are like snakebites.
+- “Let’s go steal a tear.”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*lRrwY2KClqv79Ezsj6PIJA.gif)
+
+```
+-   *awkward flirting intensifies*
+-   Uh oh!
+-   Ryan Robbins (Henry on “Sanctuary”) as Violet’s dad.
+```
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*tMBzGKkFfN5x3gP--Mo93g.gif)
+
+- Henry is getting Dark Mom to help find Violet’s horse.
+- Merida trying to make Gold into a hero. Probably not going to work.
+- “Did your dad teach you that move?”
+- The moms giving Henry dating advice. Love it.
+- Oof, this is harsh.
+- “She thought it was for the best.” — basically everyone’s motivation on this show.
+- Clever, Regina.
+- Oh, maybe we’re using the song just a little too much? Yazoo had a whole lot of great songs.
+- “Is that magic?” No, it’s Pepsi. I guess Storybrooke is a Pepsi town.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*Qg7VJ391JkeZK6mYa6MARw.gif)
+
+- What movie are we watching… “Harold and Maude”??
+- Oh ouch. Friendzoned.
+- Peter Peter’s pumpkins.
+- “Let’s hang around the new Dark One’s house when she’s heading back.”
+- Eye of newt, an ounce of Sprite…
+- You were showing off and boasting, Henry. Not very attractive.
+- The potion supercharged Emma’s magic with dark and light. And it worked!
+- The blade that was broken…
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*K9h5mtuyRehc6Opi7epTAQ.gif)
+
+- Destroy Light Magic!
+- The bears, meaning her brothers.
+- Amy Manson just tearing it up as Merida.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*ilG9BQUrbM5R_h3ZuKbkdQ.gif)
+
+- Oh dear. Emma forced Violet to spurn Henry, to get his tear, to free Merlin. She knew Regina’s tear wouldn’t be enough.
+- Merlin un-ensorcells MM and David.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*Usddh15TtDcT6zEcoBg-hg.gif)
+
+- “You were expecting someone… older?” They didn’t say “whiter” but they were thinking it.
+- Knock knock, hello, door dash delivery!
+- Dark Ones or Darks One?
+- The mystery of the missing memories is getting more mysterious.
+
+#### S5:E6 The Bear and the Bow
+
+“Merida’s brothers’ lives hang in the balance.”  
+Airdate: November 1, 2015
+
+- How Merlin knows what a bike is: canonically, Merlin lives backwards, from future to past.
+- “Do we simply speak into it?” It’s not a phone, Killian.
+- Can’t believe Belle is still, STILL sticking up for Rumple. (Of course I can)
+- Oh no, not Chip!
+- Belle and Merida chatting, until Merida clocks her in the back of the head with a blow that would probably be fatal.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*ijHL1eHMbL29vw5YroU1eA.gif)
+
+- “Hit first ask questions later” kind of lass.
+- Someone is coming up from the catacombs… It’s Gold!
+- “I’m in danger!”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*tPIFKiaqNjOhBz6Vd_a3DA.gif)
+
+- Macintosh, MacGuffin, and… Dingwall.
+- Funny how the witch is conveniently away from home just now.
+- Her little Munchkin!
+- Dark Emma placed another to-go order at Granny’s.
+- “Believe it or not, that patient with the mop loves to talk.”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*SpOCPNOUaFKvpjobdwcJ_g.gif)
+
+- Zelena just shut Emma down without a second thought.
+- But we don’t want Rumple to be a hero!
+- Arthur says he needs to be alone to communicate with Merlin. This would be so he could lie to them.
+- Good one Belle!
+- No I’m pretty sure that was Merida’s fault.
+- “Anti-transformation powder”, convenient.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*HSzK2TL4HEI4OXhStZ-edA.gif)
+
+- Eyeroll at “Belle finally sees the truth about Rumple”… again.
+- Ha, not the real potion, of course.
+- Looks like the last arrow would still have killed one of the brothers.
+- Ah the convenient anti-transformation powder. Always good to have some in your bear-fighting kit.
+- APOLLO milk chocolate, as served in first class on Oceanic Airlines.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*4ZL5xE7XSUOQtQ8RbVqedQ.gif)
+
+- “You were his maid once.”
+- Rumple has spent more time being sorry for his villainy than he ever did as a villain in the first place.
+- King… Rumple?
+- Magical Toadstools don’t burn, luckily.
+- Merlin’s voicemail! Who is Nimue?
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*F1uFL6g46AacTVj7bSiy5A.jpeg)
+
+- (I’m gonna start using “Merlin’s voicemail!” as my go-to swearing choice.)

--- a/src/content/ouatrevisit/2022-12-14-ouatrevisit-s5e78.md
+++ b/src/content/ouatrevisit/2022-12-14-ouatrevisit-s5e78.md
@@ -1,0 +1,145 @@
+---
+title: "#OUaTrevisit: S5:E7/8"
+date: 2022-12-14
+description: "In this week’s #OUaT episodes, we meet a new tertiary character and a mysterious villain — are we surprised they’re one and the same?"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e7-8-acadd6cd0b17"
+---
+
+### #OUaTrevisit: S5:E7/8
+
+> Note: As previously mentioned, this will now be the canonical home of my #OUaTrevisit posts. I’ll continue posting these to [my Mastodon account](https://worldkey.io/@smartwatermelon), and linking to my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts on their respective platforms.
+
+In this week’s Once Upon A Time episodes, the writers introduce a new tertiary character and a mysterious villain — are we surprised they are one and the same?
+
+#### S5:E7 Nimue
+
+“Emma and Merlin embark on a quest.”  
+Airdate: November 8, 2015
+
+- Previously, Hero Rumple got the sword out of the stone. And Dark Emma has the dagger.
+- “1,000 years before the age of Arthur”… some grotty soldiers running through the desert and they find the Holy Grail?
+- He chose…poorly.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*SYi_Vxrb1O3F30N6hTDrpA.gif)
+
+- Drinking from the Grail also created the Forest and a tower, neat.
+- Angry Killian is angry.
+- Merlin tells the kid in the red robe to “check on the brooms.” 🧹🧹🧹🧹
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*3a_apfEJzAl0UiRFsXNjng.gif)
+
+- I suspect this person (Nimue) is lying.
+- Ever in motion is the future, ya know.
+- One little spark? 🐉
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*4dDWQxc7iBA2C4bxznco4w.gif)
+
+- Emma is the most powerful Dark One “ever”, huh?
+- Piercing-eyed, smoldering pirate.
+- I think her whole plan was to get the Grail from Merlin. But I’m naturally suspicious.
+- I had Nimue pegged as the First Dark One.
+- Zelena’s eye-rolls are delightful.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*03Rnrae4bH6jGIs6fNk7Kg.gif)
+
+- Sir-Castic!
+- Conveniently abandoned tunnel.
+- They don’t know yet that the whole castle is an illusion.
+- Arthur is getting pretty obsessive.
+- This is war, Peacock!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*_Vch1DGbxeSHcazqcN2noQ.gif)
+
+- “In the future, they’ll call it…”
+- Do we think she sipped from the Grail just then? She was able to hold it without melting.
+- “Zelena hasn’t screwed us” (except Robin)
+- This seems like a bad idea, melting the Holy Grail.
+- The sword was formed with the inscriptions and whatnot already on it.
+- Vortigan and Nimue working together? Maybe not.
+- It’s buzzing, like a pager on vibrate mode.
+- Ah hah, I knew it!
+
+```
+-   *squish*
+-   Merlin is a useless tool, really. Just standing there reacting.
+-   Finish him!
+```
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*vWSRWfkcOTpnC3MmTLtBVw.gif)
+
+- “You don’t know the power of the Dark Side”
+- “I’ll be right here” 👉
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*cBNyF24WumpQd-pFz72rSg.gif)
+
+- Is it the right path though? Because clearly, it didn’t work.
+- Wiping out the darkness already didn’t work once. Why do we think it’ll work now?
+- “I prefer a straight fight to all this sneaking around.”
+- My feet! I can’t feel my feet!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*HCvHV8Kbl5SdeOw-H2d5tA.gif)
+
+- That’s a lot of Darks One.
+- Woohoo, she did it.
+- Aw, the little clip from The Sword in the Stone.
+- I have the power!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*A25TSkpFo5cT5Dn2feNGOg.gif)
+
+#### S5:E8 Birth
+
+“Merlin delivers an ultimatum to Emma.”  
+Airdate: November 15, 2015
+
+- David doesn’t knock. Can you knock on a tent?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*-VSFs8TFJnQ6A_o-ACoXWw.gif)
+
+- Maybe Killian should’ve been out back of the tent?
+- Arthur really just lives in his armor.
+- Why am I doing all this? Because ACTING!
+- If you walk around in a white cloak in the forest, it’s gonna get filthy.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*DvKJC8xI-FZDwba0RHBD1g.gif)
+
+- Merlin is “tethered” to the sword the same way the Darks One are tethered to the dagger.
+- “He’s not important anymore.” (Wah wah)
+- Regina has been reduced to quips and being annoyed.
+- Actual good advice from Gold.
+- Is that the snow globe from St. Elsewhere?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*LK2ITiJ36nnT99A77vGarw.gif)
+
+- Operation Light Swan explains where Emma’s new digs came from.
+- Oh, Zelena is all dressed up.
+- This is the same kind of pregnancy we saw in TNG “The Child”.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*5Mg_B-Q_vuq4odufy02CaQ.gif)
+
+- Jennifer Morrison is down-modulating her voice even more than usual this week.
+- Good thing this place happened to come on the market. And at 2015 interest rates!
+- “When the Dark One gives you onion rings, don’t take them!”
+- Yay, it’s Doctor Whale! With the Blaine hairdo straight from iZombie.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*JDtlBUHGt4ov1LTjkZOFJQ.gif)
+
+- He bravely ran away.
+- Let’s blow this thing and go home.
+- Regina’s outfit, the cloak over the dress, is amazing.
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*fXJgXjh1j_stk6Svt3TmYw.jpeg)
+
+- Brave enough? Where’s Merida hiding?
+- Aw, poor Whale.
+- Emma wanted Zelena?
+- Uh, we’re going to make Zelena the new Dark One? Seems bad.
+- The future’s nothing to be afraid of, they said in 2015.
+- Did the real estate listing mention the catacombs under the house?
+- What happened to Killian that getting stabbed didn’t hurt?
+- Today’s Special at Granny’s… Flaming swords?
+- Let’s maybe not make Killian another Dark One.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*P4uGxLMSm_5YA0MA7aVWQw.gif)
+
+- The Dark Couple. Captain and Mrs. Dark.

--- a/src/content/ouatrevisit/2022-12-21-ouatrevisit-s5e910.md
+++ b/src/content/ouatrevisit/2022-12-21-ouatrevisit-s5e910.md
@@ -1,0 +1,141 @@
+---
+title: "#OUaTrevisit: S5:E9/10"
+date: 2022-12-21
+description: "In this week’s Once Upon a Time episodes, Amy Manson returns as Merida, and Meghan Ory returns as Red. And, I guess, other stuff happens."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e9-10-f4269960d54c"
+---
+
+### #OUaTrevisit: S5:E9/10
+
+> Note: As previously mentioned, this will now be the canonical home of my #OUaTrevisit posts. I’ll continue posting these to [my Mastodon account](https://worldkey.io/@smartwatermelon), and linking to my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts on their respective platforms.
+
+This week, we’re watching as a formerly wondrous kingdom crumbles under a despotic, chaotic new ruler who issues random decrees without considering the effect on his subjects. _But enough about Twitter…_
+
+In this week’s pair of Once Upon a Time episodes, Amy Manson returns as Merida, and Meghan Ory returns as Red. And, I guess, other stuff happens.
+
+#### S5:E9 The Bear King
+
+“Zelena and Arthur journey to find an enchanted relic.”  
+Airdate**:** November 15, 2015
+
+- This all happened in the six-week Camelot interregnum, remember?
+- We’re going to visit Merida!
+- DunBroch is quite pretty.
+- The witch looks a lot like Carol Kane in The Princess Bride.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*iAjh8ypUEWWTwrEZuO0Suw.gif)
+
+- “You’ll get exactly what you want,” says the witch, foreshadowingly.
+- Seems like nothing can ever happen in a great hall without a witch bursting in saying she wasn’t invited!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*GPFBkFv9bwr77fu-6xX28Q.gif)
+
+- I wonder if Merida and Arthur+Zelena are questing for the same thing. (obviously)
+- Merida’s battle outfit is fantastic. We definitely needed the walk-around character wearing that.
+- I recognize that cloak. It’s Mulan!
+- Aww, there’s been a falling out in the two years since the battle.
+- What happened to her is that Aurora married Philip. 💔
+- This training montage is brought to you by Highlander.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*vIHimzr1yWvwYWmvHAPY_w.gif)
+
+- Zelena plays that expecting mom thing way too much.
+- Amy Manson is here just killing the Merida role. I was so sad to learn (just now) about The Nevers being [canceled](https://www.cbr.com/the-nevers-canceled-hbo-max-removed/). Hopefully, we get to see the remaining six episodes sometime soon.
+- How has he inspired the men? With a speech and a brawny chest, and would you look at that beard! (And a sneaky enchanted helm.)
+- Nobody ever knocks at the witch’s cabin.
+- Red!!!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*CKo_avZJ7gk32lB2OHIB5A.gif)
+
+- Oops, wrong thing to say.
+- How did I end up back here? Well, I [went off to do another show](http://tvline.com/2015/09/08/once-upon-a-time-season-5-ruby-returns-meghan-ory/), and that didn’t work out, so…
+- She’s not the only one of her kind, Granny is also a wolf.
+- They grew a bean. Cute retcon of Meghan Ory leaving the show. Does she stay around now?
+- Oh hey, I know a specialist in tracking! 🐾
+- They can take our lives but they’ll never take our outrageous accents!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*FcGva-18kotIz6jVbt_0kQ.gif)
+
+- The producers got the entire cohort of the local SCA chapter for this scene.
+- Oof, that was more graphic than I expected. Stabbed him in the back.
+- It was Arthur! What a jerk.
+- Hello, my name is Merida of DunBroch. You killed my father. Prepare to die.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*ZnZGOSPLJwmCTLaq1OfcPg.gif)
+
+- Super classy, your Majesty.
+- Go Red!
+- So-called Arthur-king.
+- I wouldn’t trust Zelena to drunk-transit, myself.
+- Loved Merida’s slight eye-roll when she realized it was a test.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*ejKS8jjPy2gN1Y8qblx8Ow.gif)
+
+- I want to see the team-up movie with Merida, Mulan, and Red.
+- The way Mulan’s voice broke a little when she told her story.
+- Oh boy, Arthur is going to be In For It.
+
+#### S5:E10 Broken Heart
+
+“In a Camelot flashback, Hook becomes a Dark One.”  
+Airdate: November 29, 2015
+
+- So the “One” part of the name is no longer strictly accurate.
+- Killian is extra growly this week.
+- Will the wristband work on a Dark One though?
+- Hook is gonna love having Rumple as his Jarvis.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*JQUjxgumzme58FccTEsIDg.gif)
+
+- Regina’s makeup this week seems extra broody.
+- I love how Colin O’Donoghue is chewing the scenery!
+- The “Dark One Chronicles” is a new spinoff series.
+- I’m confused about what memories Killian took from Emma.
+- Henry is almost as tall as Emma now.
+- Lancelot’s mother is the Lady of the Lake? How does that even work? And MM dropped it as if we already knew.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*wnt84As1xURI72yIW1laSA.gif)
+
+- “Why do Dark Ones always dress like monks?” This also explains Dark Emma’s outfit.
+- Will Belle give Rumple yet another chance, now that his darkness is gone?
+- I almost thought Nurse Ratchet was going to have some power to keep Zelena out.
+- Who’s watching the new baby while Zelena and Regina are sniping at each other? The Charmings? Cindy and Jasmine’s babysitting service?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*UFnjXYSQTCd-rPu59R1aDw.gif)
+
+- “Baby Hood”
+- Yes, let’s remember she murdered Marian.
+- What did Emma do to Merida?
+- “I used to be the queen of DunBroch until I took an arrow to the knee.”
+- Emma is remarkably calm here while Killian just rips into her.
+- “You’re only a pawn if you don’t know you’re being used.”
+- Flashback Killian’s outfit is very Matrix 2 Neo-esque.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*9Me-eN5AfVlxB6G_MMr6jw.gif)
+
+- If you deleted every “I did it to protect you” from this show, you’d have nothing left.
+- Ooh, Killian figured out his Dark One magic pretty quickly.
+- How is Gold going to beat Hook? Though he’s the hero now so I guess it’s forgone.
+- “Once you go green, you’ll never go Queen.” I honestly can’t believe they got away with this line.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*or-MGpMggXp7PNdG65khlA.gif)
+
+- We’re doing shared custody. That was a hard decision but it was the right thing to do.
+- Eh, maybe don’t put Emma in charge of naming sequels.
+- Pretty sporting of Killian to fix Gold’s limp before they fight.
+- We see Merlin recording his OGM.
+- Clever loophole.
+- Dark Emma saving the day?
+- Huh. He actually did it. And now, yet another curse.
+- Seizing the brief moment of distraction, Gold leaps to his feet, holds Dark Killian at bay with Excalibur, and… lets him go.
+- Hah, Belle is finally done with him.
+- We’re starting to catch up to real-time now.
+- It was a bad call, Emma! A bad call!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*Y6ccBxfZszR710iBs-2e9A.gif)
+
+- Where’s Grumpy to shout about another curse?
+- You’d think they would all be used to it by now, anyway.
+- I don’t like dreamcatchers being used this way.
+- A portal to the underworld, and here comes the Dark Squad. You could probably field a football team with this many Darks One.

--- a/src/content/ouatrevisit/2022-12-29-ouatrevisit-s5e1110.md
+++ b/src/content/ouatrevisit/2022-12-29-ouatrevisit-s5e1110.md
@@ -1,0 +1,155 @@
+---
+title: "#OUaTrevisit: S5:E11/10"
+date: 2022-12-29
+description: "Welcome to the Underworld! For the last #OUaTrevisit of 2022 we’re taking our first trip downstairs."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e11-10-e9e898b57269"
+---
+
+### #OUaTrevisit: S5:E11/12
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+_If there’s one God you don’t want to get steamed up  
+It’s Hades, ’cause he had an evil plan  
+He ran the Underworld  
+But thought the dead were dull and uncouth_  
+ — The Gospel Truth II, Disney’s Hercules, 1997
+
+Welcome to the Underworld, foolish mortals! It’s the last Wednesday of 2022 and we’re closing out year two of #OUaTrevisit with our first trip downstairs and a meeting with the man himself.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*44pId8uNne6W_Kk9yP-0-A.gif)
+_No, not that Hades._
+
+#### S5:E11 Swan Song
+
+“The Dark Ones prepare to obliterate light magic.”  
+Airdate: December 6, 2015
+
+- Just gonna stop making the Light Magic joke at this point, okay?
+- Young Killian!
+- Isn’t Rumple all good and stuff now though?
+- “There’s more than one Dark One!!” — Leroy/Grumpy
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*q06VvWePi8UU9r-XvjT5qQ.gif)
+
+- I’m altering the bargain, pray I don’t alter it any further.
+- There was a deal on Dark One cloaks at Costco.
+- “The Mark of Karen” gives the holder unlimited power to speak to the manager.
+- Cheery speech from Rumple.
+- Previously, when Regina still had AMAZING outfits…
+- “What’s in the carriage?” “Pain.”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*fsmhNpx6ETyDhTuAfkQRrA.gif)
+
+- Dinner at Granny’s, obviously.
+- “Nothing’s wrong,” Rumple lied, again.
+- Great plan, Emma, except for the part where it kills you.
+- Queen Regina just swanning into the pub.
+- Save the clock tower!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*f0SJBSbp2IJIZRUYn2ByqQ.gif)
+
+- So long, Zelena. For now.
+- Dad Jones looks familiar. Played by [Adam Croasdell](https://www.imdb.com/name/nm0189488/).
+- Convenient TLK is convenient I guess.
+- Since when do people need Letters of Transit to leave the Enchanted Forest? Is this Casablanca?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*hPRKXWDfvGtWAt8hymSMTg.gif)
+
+- Ooh, Killian has a half-brother. That’s not going to feel good.
+- Ugh, Emma was so easily suckered.
+- The S.S. Purgatory sounds like a ship from Lower Decks.
+- “I know what I have to do but I don’t know if I have the strength to do it”
+- Hey, Killian finally found a backbone. But who will be the sacrifice?
+- No more Dark Swan, but also no more Hook.
+- Apparently, there’s a Storybrooke ambulance service, which also implies a Storybrooke coroner’s office. I wonder if Tink works there and knows Dr. Whale?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*4jA5SqsJsuYAUF6-yhZfwQ.gif)
+
+- Uh oh, dark whispers.
+- How could he have the dagger? Wasn’t it part of Excalibur?
+- “A small vial of magic” is just $8.99 at Walgreens.
+- Rumple/Gold fully returning to form. Not sorry, honestly.
+- She has to pay the toll. And not look back on her way out.
+- Observe the duck in the Evil Pond just trying to get out of the way of the Evil Canoe. (42:07)
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*SLYEgEzu-OtsMNunL5kuuA.gif)
+_Can’t take screen captures of Disney+ 🤦‍♂️_
+
+- Wait, we’re all going? I thought it was just Emma.
+- “I will always find you.” She said it!
+- This was the mid-season break. We resumed three months later.
+
+#### S5:E12 Souls of the Departed
+
+“The heroes follow Hook to the underworld.”  
+Airdate: March 6, 2016
+
+- Are we perhaps talking about the same Underworld from “Hercules”?  
+
+```
+    (Is the OUaT Synergy Machine cranking overtime, Bob?)
+-   The Underworld is a spooky closed theme park. Huh.
+```
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*O43oRZAm-BcnMpK4hW3jXg.gif)
+
+- Neal!
+- The coaster is named “Revelation” (not “Revolution”).
+- Gold went too??
+- Is there, like, an Underworld reception desk, or a welcoming committee?
+- Oh yeah, Emma threw Cruella off a cliff.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*S-IlWac4BVL2reG0H49cHw.gif)
+
+- Regina just sticks her finger in the pie.
+- Blacktooth? Who the heck is Blacktooth? Oh never mind.
+- Oh hey, Dad, nice to see you.
+- Cora!!
+- Everything here is the dark and spooky version.
+- It’s the witch from Hansel and Gretel! Played by [Emma Caulfield](https://www.imdb.com/name/nm0146536/).
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*TCKs5VtoliaA_hbPBkr8Ww.gif)
+
+- That’s not David, it’s James. Right?
+- “What if he had no unfinished business?” Are we talking about the same Killian Jones?
+- I love Evil Regina plucking the flower.
+- Sidney! We’re getting all the old favorites.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*D01R5468hbiGTKCSA8-HvQ.gif)
+
+- Oops, Henry left the door open.
+- Convenient that everyone has their magic down here.
+- Aww, Blacktooth gets it again.
+- The spinning wheel in Underworld Gold’s shop is extra creepy.
+- Pan, of course. Hi Dad!
+- Are Cora and Pan, parents of conflicted characters manifested, actually there? Or an illusion?
+- The DunBroch whiskey. That’s good stuff.
+- “There’s a boat that’s leaving soon.” Is the ferry on a timetable? Are there tickets? Do they have an app?
+- Oh no! Cora has Snow’s heart. Now what?
+- (Obviously, somehow this never happened or it’s reversed and Snow has no memory of it)
+- Killian Jones has a very dramatic headstone as is appropriate.
+- Why is there a steam pipe in the middle of the graveyard?
+- That was the best camera angle and the best cake and the best look on Regina. Did she just off the jester for “not being funny”?
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*lcCko4zlA1CvKmpwW81lWQ.jpeg)
+
+- Okay, Jiminy, not cool.
+- Aww, poor rando guard.
+- Regina’s necklace looks like a chain of jeweled spiders.
+- Dad-Henry is subtitled as “Valet”.
+- Redeemed Regina. That’s all.
+- Uh oh, Cora, are you standing in front of a mirror? Again?
+- Cora grabbed Dad-Henry on the way back to Neverland. But obviously, he comes back later.
+- Aww, Dad gets to cross over. 😇
+- Henry/Henry meeting: perfect.
+- Thus begins what I recall as an interminable series of episodes in The Underworld.
+- “Operation Firebird”
+- We’re on an express elevator to Hell!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*cU29rSUdRNlxjCSdlOk1aA.gif)
+
+- Ah, Hades, here we go.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*u3MuZGUb93xfL6G0FGNbfQ.gif)

--- a/src/content/ouatrevisit/2023-01-05-ouatrevisit-s5e1314.md
+++ b/src/content/ouatrevisit/2023-01-05-ouatrevisit-s5e1314.md
@@ -1,0 +1,105 @@
+---
+title: "#OUaTrevisit: S5:E13/14"
+date: 2023-01-05
+description: "It’s the first #OUaTrevisit Wednesday of the new year. It’s also my first day back at work after the holiday break."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e13-14-8afbfb05e0f"
+---
+
+### #OUaTrevisit: S5:E13/14
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+It’s the first #OUaTrevisit Wednesday of the new year. It’s also my first day back at work after the holiday break. I’m not saying I sympathize with Lord Blue-Fire but I kinda do. Anyway.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*p1QYDgFBDEdNpdxzAkNslg.gif)
+*Everything is going just great.*
+
+#### S5:E13 Labor of Love
+
+“The heroes learn Hook is held captive in Hades.”  
+Airdate: March 13, 2016
+
+- “in” or “by”? Is Hades the realm or the person? Or both?
+- Meanwhile, in the land of bad CGI backgrounds.
+- Megara! And per the credits, Cruella.
+- This seems like a trap. Remember Megara was working for Hades.
+- Cerberus looks like the demon dog from Ghostbusters, only more so.
+- David is calling her Mary Margaret this week. Next week it’ll be Snow again?
+- He’s on a diplomatic mission. This is a councilor ship.
+- Young Princess Snow bugs out of the castle, no guards spotted her, and falls into a convenient oubliette.
+- Hercules! Honey, you mean Hunk-ules. Who is apparently dead?
+- Bizarro Storybrooke.
+- I’m so glad Regina and Robin seem to be a permanent thing.
+- That disapparating was all Emma. Even without the Dark power, she’s now a full-power magic user.
+- I do not trust Megara, at all.
+- C’mon, Snow, you wanna be strong like Herc? Brave like Herc? This is gonna be harder than I thought!
+- Are we saying that Snow White’s renowned archery abilities come from Hercules?
+- Glad to see Emma Caulfield is continuing as the Blind Witch.
+- Dead Herc is so moody, he should be on a CW show.
+- I like Hades’ tie.
+- “Grandma Cora”
+- Ah, the old ventilation shaft trick.
+- Yay, Cruella!
+- Regina called him Wonderboy.
+- The long cloak is not conducive to archery.
+- Of course, the bandit is working for Regina.
+- “So we’re gonna do a half-season in another realm, but we’re gonna save a ton of money by just using a red filter and the same old sets!”
+- Unhooked.
+- The music, the gin, the glamour, the gin.
+- As I thought, Henry destroyed the quill, but its power still exists.
+- Cruella has actually a pretty good point.
+- “You made me your friend by never giving up on me.” Regina/Snow team-up forever.
+- Young Snow in a version of the huntress outfit.
+- Herc to Snow: “Can you keep a secret?” Me: NO!
+- A little bit of “Go the Distance” behind Herc’s speech.
+- For a second when the bed crashed through the floor, I wondered if it was a Bedknobs and Broomsticks reference.
+- Just terrible tactical planning by Snow in that encounter with the bandits.
+- Is this beast a manifestation of fear or something?
+- Check out the stunt doubles in the background.
+- And there’s the explanation for why David overused “Mary Margaret” in this episode.
+- Huh, I guess Meg wasn’t working for Hades this time.
+- Take this screwdriver and do something terrible!
+- Does Hades really have the power to force someone who isn’t dead to stay in the Underworld?
+
+#### S5:E14 Devil’s Due
+
+“Gold finds motivation to help Emma rescue Hook.”  
+Airdate: March 20, 2016
+
+- “Devil’s Due” or “DeVille’s Due”?
+- Hades is really Shatnering this dialog.
+- “Keep all arms and hands inside the boat, there be squirrels ahead.”
+- It’s a Pan flute, get it?
+- Oops, Gold dropped the Palantir.
+- A helpful dead person. Milah?
+- Baelfire reached out his hand to a poisonous snake. Not too smart.
+- “Morning, Dearie.”
+- It really does look like Killian is riding PotC.
+- It’s a good thing the scenery is virtual, or else Hades would have chewed it all.
+- “You’ve been with my former lover…and my son?”
+- Pooh and Tigger plush under the crib.
+- “Kendrake the Healer”, or Ken for short.
+- Maybe helping save Hook is Milah’s unfinished business.
+- “I’m not saying it’s Bambi’s mom, but I’m not saying it isn’t.” I missed Cruella.
+- “Underbrooke” — no, just no.
+- Who else is Regina looking for?
+- Happy person, tippy stone.
+- Something… Brave, you say?
+- The fabled meeting of Milah and Killian.
+- “Do you expect me to talk?” “No, Captain Hook, I expect you to die!”
+- I don’t think cowardly Rumple is going to have much luck with this heist.
+- “I’ll give you the potion but you’ll need to go on a quest for me.”
+- Ah, Regina was looking for Daniel’s stone. Which is tippy.
+- All the pool balls are red.
+- Hades is relying on other people to do things for him as if he’s perhaps unable to effect them himself.
+- “I’m sure that’s a puzzle you can solve.”
+- He traded the potion for their second child, a draft pick, and cash.
+- Oof, he really did throw her in the river.
+- Was Regina having a problem with her magic? I guess I missed that.
+- The old heart-split trick. Except not.
+- Regina, Snow, and Emma are now stuck.
+- What’s Hades reading? Faust, of course.
+- That Hades speech took me a minute to decipher: Rumple killed Fendrake during his affair with Rose McGowan/Cora to keep any potential child from being taken.
+- Hades is doing Goblin King-style glass juggling.
+- I’m already tired of the bad blue-fire effect.

--- a/src/content/ouatrevisit/2023-01-10-ouatrevisit-s5e1516.md
+++ b/src/content/ouatrevisit/2023-01-10-ouatrevisit-s5e1516.md
@@ -1,0 +1,129 @@
+---
+title: "#OUaTrevisit: S5:E15/16"
+date: 2023-01-10
+description: "It’s #OUaTrevisit of S5:E15/16 and we’re still in the Underworld."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e15-16-a257b8d817c2"
+---
+
+### #OUaTrevisit: S5:E15/16
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+This week in Underbrooke (wince), we continue the interminable Hades/Underworld arc. We’ve gone so far into interlinked soap-opera storylines that I’m having trouble remembering why our heroes (and villains) are even down there.
+
+It was to rescue Killian — somehow resurrect him after Emma ran him through with Excalibur — right? But three names have been etched on tombstones which somehow prevents them from leaving. Whatever will we do?
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*pquHCjJdHLAod6UuLPANcA.jpeg)
+
+#### S5:E15 The Brothers Jones
+
+“Hades tries to trap the heroes in the Underworld.”  
+Airdate: March 27, 2016
+
+- Have you noticed that this portrayal of Hades doesn’t really have much raw power? He mostly tries to trick or trap or betray.
+- Dead Cruella wants to be resurrected. Can even Henry do that?
+- “Dirt and things that smell like dirt.” She’s so good.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*0kTMl3c0zP7CSydM7RUjFA.gif)
+
+- What I told you was true, from a certain point of view.
+- The Apprentice is acting as the Wise NPC.
+- Good thing Emma’s magic works down here.
+- Enough with the self-loathing, Killian.
+- In the Navy, you can sail the seven seas.
+- Is this actually Liam, or is it Hades trying to get the goods from Emma and Killian?
+- I don’t think much of the righteous indignation from Liam.
+- PeeChee folders in Henry’s backpack.
+- Who is playing Captain Silver? [Costas Mandylor](https://en.wikipedia.org/wiki/Costas_Mandylor).
+- Oh, James and Cruella. Interesting.
+- Keep your distance, but don’t _look_ like you’re keeping your distance.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*fu09JGuDJYf2iV8ESAJ_Eg.gif)
+
+- There’s a protection spell on the door, too bad you don’t have the two most powerful magic-users in the party standing right there.
+- Was that a little phrase of Hans Zimmer during the mutiny?
+- Ugh, try to be more obvious about ripping the pages.
+- Haha Cruella knew the whole time. This makes me want to see Victoria Smurfit in something else.
+- “The pages could have fallen out,” right.
+- Killian did the little smile. Katie, did you melt?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*M7vKrklk3UuGemscjqEYXQ.gif)
+
+- “Please allow me to introduce myself…”
+- I’m over the blue-hair effect. It’s so poorly done.
+- Greg Germann (Hades) went to the Shatner school of acting.
+- Liam is straight-up lying to Emma. What happened to her superpower?
+- I guess she didn’t need it after all.
+- Sigh, Killian is so gullible.
+- (Watching the ship in the stormy seas makes me just a little nervous about crossing the Drake Passage next month.)
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*uGeD68tbWg0Mq2LVmuR5gg.gif)
+
+- That was unexpected. Liam sacrificed himself and thus finished his business.
+- The burlap sacks and clubs will be helpful in the afterlife.
+- It’s just a bunch of crystals glued together.
+- Everything Liam did after meeting Hades the first time was a lie.
+- Meanwhile, Henry is still looking for the pen.
+- “He’s upstairs going full emo teenager.” So David goes upstairs and does the classic “How do you do, fellow kids?”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*pEQsqFFTO_9y5nAD9Xve_w.gif)
+
+- So what is Hades trying to hide? Could it be Persephone? … No, it’s just Zelena again.
+
+#### S5:E16 Our Decay
+
+“Belle is reunited with Rumple in the Underworld.”  
+Airdate: April 3, 2016
+
+- Meanwhile, in Emerald City, Zelena is enjoying a giant cupcake.
+- The CGI Scarecrow is not so good.
+- Dorothy is back! And Toto too.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*oVTDJHs_Fa6fiafUePI7Fw.gif)
+
+- Zelena just iced one of her guards. Do they have OSHA in Oz?
+- Why is Hades sitting in a barber chair?
+- Storybrooke, of course!
+- Hmm, that’s not Mother Blue. But who could it be? (Obviously)
+- Why threaten Rumple with a dagger when he’s making the thing Hades wants? Hades thinks he’s smarter than he really is. He’s got that Glass Onion Miles Bron thing going.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*_WvFXvL_kLl4nDnEWTmNyg.gif)
+
+- Belle, Zelena, and Zelena & Robin’s daughter (does she have a name yet?) all went down the portal. And didn’t come out.
+- Why is the sky red? Either it’s The Day After or the Underworld.
+- I wasn’t expecting him to actually say it. So obvious.
+- She’s sweeping up the Munchkin ash!
+- What does Hades need with a time travel spell? What does God need with a starship?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*3Y5mzS4CUshARG3pmcS3VA.gif)
+
+- “A simple level one haunting.” Via a haunting booth, of course.
+- “It’s really well written.” “And the illustrations are lovely.”
+- They’re all living in the apartment? Like “Friends”?
+- Hades is looking for a TLK. Will he get one from Zelena? I’m guessing not.
+- They’re conspicuously avoiding naming the baby.
+- “Why would you steal a baby?”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*JG9d5x9FAmcSYhzeyXnxTA.gif)
+
+- A long time ago, longer now than it seems.
+- Rumple just admitted the deal and the Dark One all at once; he wasn’t even really trying.
+- I would like it if Belle told him to go stuff it, but I assume she’ll roll over for Rumple. Again.
+- The haunting booth is a red British Telecom call box. Should’ve been blue.
+- I love reformed Regina so much.
+- Hop on? Not in that dress. 🚲
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*1JVGbEs-F5OxWanGkF_UXQ.gif)
+
+- Aww, Hades has a crush.
+- She had just a little spark of magic. But she also still has a sprained ankle.
+- Did Hades bonk his head on her hat when they almost kissed?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*WYMBLG3URuP67Hp8ju8e0w.gif)
+
+- I’d never heard of Quadlings. Another race from Oz apparently.
+- The Sam Raimi focus pull on Hades is very nice.
+- Nah. He’s trying too hard. And even if he’s telling the truth, Zelena’s not having it.
+- “Weren’t you curious why this place looks like Storybrooke?” (It’s so they didn’t have to build new sets)
+- Zelena’s birthday is April 15th. Tax day.

--- a/src/content/ouatrevisit/2023-01-18-ouatrevisit-s5e1718.md
+++ b/src/content/ouatrevisit/2023-01-18-ouatrevisit-s5e1718.md
@@ -1,0 +1,167 @@
+---
+title: "#OUaTrevisit: S5:E17/18"
+date: 2023-01-18
+description: "It’s time for #OUaTrevisit: Season five, episodes 17 and 18. We’re still in the Underworld, but it’s getting interesting."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e17-18-3b0d80569f02"
+---
+
+### #OUaTrevisit: S5:E17/18
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+As I’ve noted, I’m kind of over the Underworld arc; but I did think this week’s pair of episodes were unusually good. We’re really starting to see some interesting character development and backstories.
+
+As I’ve also noted, I stopped watching OUaT before the final season during the original run. I don’t remember exactly when I gave up; it might have been before the end of season five or early in season six. However, I’m absolutely sure I have never seen season five, episode 18 (discussed below) — I would have remembered.
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*IbYh_ySsgvVL2bK972Zk8Q.jpeg)
+*This gave me joy.*
+
+#### S5:E17 Her Handsome Hero
+
+“Belle’s decision may cost her Rumplestiltskin.”  
+Airdate: April 10, 2016
+
+- Okay, first of all, WHAT? That slug doesn’t make any sense.
+- I had forgotten how little Gaston actually appeared in the early seasons.
+- Lord LeGume, really? Sounds pretty salty.
+- I covet Gaston’s jacket.
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*NK_bXKnnEVHE7hX7A9s2CA.jpeg)
+*I could be Gaston the Elder at the next MNSSHP.*
+
+- “So, you have accepted the truth.”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*_z7nBNYe8COGKtiDWYKbHQ.gif)
+*Belle has accepted that Rumple is always going to be the Dark One, but she can’t live with him?*
+
+- Oh right, because Merlin had such great ideas.
+- Was that an ogre? I’ve got an ogre-slaying knife, it’s plus-nine against ogres!
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*HlChP1tXHmfs_XZ1fT5axQ.jpeg)
+*Can I have a Mountain Dew?*
+
+- Is that an Oz-tornado?
+- So MM *didn’t* just get whisked away by something?
+- I really like how Regina is now casually using Emma’s name with no snark or sharpness at all.
+- Pretty sure the centuries-old pirate who’s seen it all would know runes when he saw them.
+- Did they try speaking “friend“?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*E4V4aBN1Jv0ASOdjAGG5NQ.gif)
+
+- I’m fascinated by this take on Hades as just another powerful magic-user. Not a deity; just someone who, with the right set of skills and knowledge, can be defeated.
+- Ah, the cemetery scene was a premonition.
+- A flower grows in the Underworld.
+- I assume Gaston has six or seven dogs?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*3reFBfMLHQYKkqk9lO54PQ.gif)
+*Six or seven dogs sounds like the right number.*
+
+- I hope we see LeFou in a future episode.
+- It’s a trap! Probably.
+- I like the way Emilie de Ravin pronounced the word “nefarious”.
+- Yes, Belle, ONCE AGAIN.
+- Back in the Sad Cafe with Emma Caulfield.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*9S6F2-lLaZACRi5w9D39dw.gif)
+*“Can’t you see there’s a fly in my soup?” “No!”*
+
+- Do you think Hades, the powerful magic user who rules this land, won’t find someone in the forest?
+- Rumple has a point.
+- A record of every magical item in the kingdom, interesting.
+- No, “A Woman of Substance” is a different book.
+- “I’ll watch over the ogre” meaning kill it, probably.
+- I think the animal shelter set has been used as the back of Granny’s.
+- Yay, another Regina dig at Killian.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*u45s0Wlr_YhBEsPlph_YqQ.gif)
+
+- “I don’t have any issues” says the ex-Dark Savior.
+- Shot him in the back. Classy.
+- There’s the Gaston I know!
+- Ah, that’s a lie. Gaston wants to kill the ogre, so he allowed it to escape.
+- “Belle, you can trust me.” — someone who has never told the truth, ever.
+- Here we come, we’re fifty strong, and fifty people of ambiguous origins can’t be wrong.
+- A flash of red in Gaston’s eyes in the mirror. Obviously.
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*pdPZZ0yY2ayCBiwe4z7kTg.jpeg)
+*Don’t I deserve the best?*
+
+- The ogre kinda looks like one of the blue Avatar people.
+- Ohh nice job Belle, getting the dagger!
+- Oops. 🌊
+- Ugh, Gaston is such a… whatever.
+- Now, why would you hand it back to him?
+- If you aren’t going to order anything, you can’t just sit here and use the wifi.
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*y6u-2wvT2Nt0OBnKXPUyzA.jpeg)
+*But the Internet at my Sad Cottage sucks!*
+
+- Red!! 🐺
+
+#### S5:E18 Ruby Slippers
+
+“Ruby enlists the heroes to find Dorothy.”  
+Airdate: April 17, 2016
+
+- I’m always happy to see Meghan Ory in the credits.
+- She’s sniffing in the wrong place!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*-gWen6t3eGAbjmbps1kxPw.gif)
+*Bad dates.*
+
+- A strip of gingham. Now, who wore that… 🌪️
+- Ruby was still hanging out with Mulan. I’d love to see a spinoff of their adventures.
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*lHWnIgWiZcB3iIVi7cy2kQ.jpeg)
+*Via Meghan Ory’s Instagram: [https://www.instagram.com/p/BGAnXmsMNpj/](https://www.instagram.com/p/BGAnXmsMNpj/)*
+
+- Talking about seeing “The Wizard of Oz” in Storybrooke. This brings me back to a point from very early in the Revisit about what happens if you know your life is from fiction.
+- Also, refresh my memory, I don’t think Mulan was ever in Storybrooke, was she? She stayed with Aurora and Philip and then (we discovered later) went to train Merida.
+- Toto!
+- Episode directed by Eriq la Salle, known for a lot of things including Darryl Jenks in “Coming to America”.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*PfId3xb6rnkknATyZAKVNg.gif)
+*Hey.*
+
+- What did Zelena do to Ruby?
+- Whatever Hades suggests is automatically a bad idea.
+- Zelena wanted Dorothy’s silver slippers so she could get back to Storybrooke. After Regina sent her away in a tornado. The timeline here is a little mangled.
+- “Chisel Chin Junior” is another classic Cruella-ism. I suppose the end of the Underworld arc will also be the last we see of Victoria Smurfit unless Henry actually does author Cruella back to life.
+- The whiskey bottle is labeled “Moloch” and I really want that bottle.
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*MK0WLAY84dtacHY8fSavvg.jpeg)
+*Me too, Zelena, me too.*
+
+- Poppies will put her to sleep!
+- Dorothy is seriously grumpy.
+- This exposition is brought to you by the *looks* between Ruby and Dorothy.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*ttlkZB2jH_a1HPKzJlVvRQ.gif)
+
+- Killian’s hair looks weird, right?
+- Do the slippers work for more than one person at a time?
+- Oh right, happy endings, haven’t heard that plot point in a while.
+- Are you going to do something at least adjacent to the right thing, Zelena?
+- Those meaningful looks again. I think I know who’s going to give Dorothy her TLK.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*O7MvBOOlaTT5E_0iw7f1cQ.gif)
+*Is it just me? It’s not just me, right?*
+
+- “No dogs allowed.”
+- I… was not expecting that fate for dear sweet Auntie Em.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*respEdUqFi0PK_Ae7YpoOA.gif)
+*Just kidding!*
+
+- You’re kind of wearing it on your sleeve, there, Ruby.
+- “Love’s a funny thing, when I met Charming, I hit him in the face.”
+- Ooh, I want Hades’ bar cart. I can’t find a picture of it.
+- Mulan took care of someone else under a sleeping curse. Had to have hurt.
+- ❤️😭❤️😭❤️
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*Gk2mDhgsMXF3TXztJUqJSQ.gif)
+*This Grinch’s heart grew three sizes that day.*
+
+- Did ABC ever publish the Book?
+- Belle puts herself under the sleeping curse. And Rumple says he can’t wake her. That’s kind of sad.

--- a/src/content/ouatrevisit/2023-01-25-ouatrevisit-s5e1920.md
+++ b/src/content/ouatrevisit/2023-01-25-ouatrevisit-s5e1920.md
@@ -1,0 +1,146 @@
+---
+title: "#OUaTrevisit: S5:E19/20"
+date: 2023-01-25
+description: "With episodes nineteen and twenty of season five done, there are only three more episodes (two #OUaTrevisit posts) until our Spring hiatus."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e19-20-b2da4b5f28a7"
+---
+
+### #OUaTrevisit: S5:E19/20
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+With episodes nineteen and twenty of season five done, there are only three more episodes (two weeks of posts) until our Spring hiatus. And wow, do I need the break after the back half of this season. Let’s get to it!
+
+#### S5:E19 Sisters
+
+“Regina turns to Cora for help with Zelena.”  
+Airdate: April 24, 2016
+
+- Does Zelena know what Hades did to Cora?
+- “I don’t want to set the world on fire…”
+- The car looks like “Christine”.
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*MWw5Z8P2Fd8K44f9wjIy-A.jpeg)
+*Let’s all go to the drive-in.*
+
+- He’s still trying that TLK gambit. And I bet Zelena is still going to see through it.
+- Is *everyone’s* name on a tombstone now? Could be a problem.
+- Regina fixing her hair in the magic mirror.
+- Have we seen young Regina before?
+- The doll kind of looks like Snow.
+- What’s in the box?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*5g9ZUN-iUGrcH6X7DqCLFw.gif)
+*Could be anything!*
+
+- Okay, that’s not good. Enchanted dolls never work out.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*KA4sh-dxRGTiYF9XhM2YGw.gif)
+*Was it “Talky Tina” or “Talking Tina”?*
+
+- It’s a step in the right direction (after all).
+- This week is extra soapy, even for this show.
+- I don’t like his way. 🧟‍♂️
+- How did Cora still have her magic?
+- That’s a useful skill.
+- “Are you a good witch, or…”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*rDx_SCij8YYMOmb29BbgjA.gif)
+*It depends, is this the movie or the stage musical?*
+
+- Cora is being extra manipulative here. Using her first daughter to help her second.
+- Two Brothers, on their way.
+- He tased him!
+- MM immediately knew the last time James tried to impersonate David. Will Emma use her occasional superpower to spot him?
+- Has Regina forgiven Cora now? The alliances shift constantly.
+- Ah, Regina is using Cora, and Cora is walking right into it.
+- “There was a spring from this very river near our estate, which I used to make you and Zelena forget each other when you were teens.”
+- “Why is everything in the woods with you people?!”
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*O3ufCs9ADfbw5Jv6ij301w.png)
+*I’ll miss Cruella when she’s gone. If she’s ever gone.*
+
+- Ugh, unexpected visits from relatives are the worst.
+- Mom heard the whole thing.
+- “Well, are you?” “Nah.”
+- Why don’t I go out of the room to get you some water instead of magicking it up right in front of you?
+- (Nelson laugh)
+- Young Zelena in this scene looks like Glinda.
+- Mom just turning off the sisters’ fireballs.
+- That was a very powerful scene with Cora restoring their memories.
+- Of course, James and David are wearing the same jacket, so we’ll be confused about which one dies.
+- 🌊
+- Poor James, poor poor James.
+- Nice that Cora gets to Move On, but given her entire history of evil, she’s unlikely to go to the Good Place.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*rQ7h0bmHoi5sYYgpyuNtWQ.gif)
+*Unless someone loses her file.*
+
+- Okay, I love the sisters reconciling.
+- The special of the day is dry white toast and tapioca pudding.
+- “I hear you’re wicked, well I’m much worse.”
+
+#### S5:E20 Firebird
+
+“Emma and Hook’s love faces the ultimate test.”  
+Airdate: May 1, 2016
+
+- Road trip? Moving in together? *Shared laundry loads?*
+- Love Regina and Killian sniping mostly good-naturedly.
+- Emma looked up when Hades said her name like she’d been scrolling through her phone.
+- Hipster Glasses Emma!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*J2404PGygGNGmhT2osGPFA.gif)
+*It’s convenient shorthand for “this is a flashback scene.”*
+
+- Do we find out now why Emma still has the Beetle she stole?
+- Tearing a long strip of paper like that all in one go is difficult.
+- Hey, the plan actually worked. Is Hades not bullshitting?
+- Wow. Turns out the way Hades gets his happy ending is to accept love and trust. That’s kind of been the whole point of this show.
+- Isn’t Killian still technically dead? How are we going to deal with that when it’s time to go home?
+- Oh right, the heart split. But it’s too late.
+- It happened once, a long time ago.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*RWJQQwH4hlI3dErVWVcXUw.gif)
+*I saw it at the Orpheus.*
+
+- It took Emma all of four seconds to pick the lock on the cuffs.
+- TRAKR Interstate Record Finder.
+- This quest is very complicated. Emma and Killian need to take the elevator down to the lower levels. There, Emma will take a test to prove she’s worthy of receiving Ambrosia. If she gets it, she feeds it to Killian, which restores his life?
+- “Without magic, how am I gonna take out my own… ow.”
+- Ah, I think this is the ultimate test promised earlier.
+- Disappointing for Rumple that his kiss didn’t wake Belle.
+- What’s in the box?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*nSddo-UIzUSeTdjnbKnTCA.gif)
+*I assume it’s a box of cookies.*
+
+- The Baby, who still doesn’t have a name.
+- Rumple took Robin’s heart to give to Pan.
+- Stealthy!!
+- Cruella and the Blind Witch, who still doesn’t have a name. Great outfits.
+- “Only the penitent man will pass.”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*QVt6SaKbbClVPuvRbFPwvg.gif)
+*And the penitent man must have a ticket.*
+
+- She had to save herself or save him. And she chose him.
+- Good thing the cops didn’t cover the back of the building.
+- The ambrosia tree was cut, Regina and friends are stuck in the library, and Hades escapes with Zelena. Yeah, it was all his plan.
+- Is this… The End of Hook and Swan?? (Probably not)
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*0RuCpBf1jZVZBe-5jiSvDA.gif)
+*Until the season-ending cliff-hanger, I assume.*
+
+- That’s a whole lot to spring on someone unexpectedly while they’re at work.
+- The jacket!
+- These two should be able to break that spell.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*4018k46Hspsr7jlQFaPQmg.gif)
+*I want to see this spin-off show.*
+
+- Nice work, Henry.
+- Curse your sudden but inevitable betrayal!
+- Phenomenal cosmic powers, itty bitty living space.
+- Through the portal, barely in time.

--- a/src/content/ouatrevisit/2023-02-01-ouatrevisit-s5e2122.md
+++ b/src/content/ouatrevisit/2023-02-01-ouatrevisit-s5e2122.md
@@ -1,0 +1,165 @@
+---
+title: "#OUaTrevisit: S5:E21/22"
+date: 2023-02-01
+description: "This week: we’ve had enough of Hades; let’s set up next season’s Big Bad. We lose a hero and gain a family relationship. Hello Vancouver!"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e21-22-8cbc914bd3e9"
+---
+
+### #OUaTrevisit: S5:E21/22
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+This week: the writers decide they’ve had enough of Hades, and set up next season’s Big Bad. We lose a hero and gain a family relationship. And we visit Vancouver again!
+
+#### S5:E21 Last Rites
+
+“Danger looms as Hades grows more powerful.”  
+Airdate: May 8, 2016
+
+- “Snow White still thinks I’m a villain,” (which he is, obviously)
+- Zelena has been taking lessons from Belle in “I can change him.”
+- Arthur, meet Hades. Goodbye, Arthur.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*26fenUfJnvFVVDba9wy4Ag.gif)
+*I can defeat you with one hand holding a baby!*
+
+- Sleepy was on guard duty! Merida didn’t have much to choose from.
+- We all made it back! Except for Hook.
+- Dead Arthur is now in the Underworld.
+- “Denial, grief, anger, can we just get to acceptance?”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*O4rR-Jis9JRDuRIS1gjL5g.gif)
+*Anachronistic from Killian, but perfect.*
+
+- Gotta balance the books somehow. Let’s go on a quest!
+- David is so useless when he tries to be fatherly.
+- Gullible Zelena, again. Ridiculous.
+- Why does Hades have his brother’s crystal?
+- Robin makes some good points here.
+- “Game of Thorns” flower shop.
+- Did Emilie de Ravin take some time off at the end of S5, is that why she’s “under a sleeping curse”?
+- Hidden in the throne, look at that. Nice work, Arthur.
+- Too bad the ghost phone was removed.
+- If “Stubble sandwich” is really the very last we’re going to see of Cruella, well, I’ll be sad.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*n9cquNGUrlePQY2QKXRNbw.gif)
+*Hard to see how they might bring her back now that we’ve (finally) moved on from The Underworld.*
+
+- Emma’s writing in this episode is kind of odd, as is her makeup.
+- Hades is literally telling Zelena that she’s just a means to an end. And she doesn’t want to believe it.
+- The call was from a flip phone to a landline.
+- Good show, Robin. Except I just got a premonition about this plot: Usually, the next thing after making an emotional leap and finding your destiny is being tragically killed.
+- Magic book is magic!
+- Always with the swords. Didn’t these people learn anything from Excalibur?
+- Hades strides past without looking. Helpful!
+- As I thought. Too bad. But now Hades will face the power of this fully operational battle station, I mean, Regina.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*VCvhk5z9v29GgxLJbJ7Dtg.gif)
+*He’ll be back as a Force Ghost, I assume.*
+
+- Boom! Zelena does it!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*b9TOqyHrNpK4DLKuzZlIzQ.gif)
+*I saw this coming from the scene blocking but it was still a shock.*
+
+- But with Hades gone, the position of God of Death is vacant.
+- Was that going to be enough for Arthur to move on? And Killian too?
+- Is this… Zeus?
+- Where exactly does Killian belong? I think I know.
+- Oh, Robin’s funeral is just heartbreaking. 🏹
+- 😭 Robin is a good name for the baby. 😭
+- “This is not your fault.” “(Didn’t really think it was, but okay.)”
+- Aha, I knew it! (Maybe remove the headstone, awkward.)
+- Now, what’s Rumple going to do with the pile of dust formerly known as Hades?
+- Ah, the shard from the crystal (that’s a different movie).
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*hKiBD5o10Cuqzt0PVt8MSg.gif)
+*Once more, he will replenish himself.*
+
+#### S5:E22 Only You
+
+“Regina reels from the loss of Robin Hood.”  
+Airdate: May 15, 2016
+
+- Shockingly, the producers did not use the Yazoo song in this episode, despite the title.
+- Why a dirigible in the opening sequence? From Oz, perhaps?
+- David and Snow are the worst at comforting. Just the worst. Mostly David though.
+- Okay, if Killian’s resurrection “pushes Regina over the edge” into returning to evil, I’m gonna be depressed.
+- “Delicate as always” … at least she didn’t flip out right away.
+
+![Screenshot from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*lMnthqobhElVOSxCH99Esw.jpeg)
+*Wince!*
+
+- Emma blew it. Regina was ready to go.
+- Henry knows the combo to the safe, that’s convenient.
+- While pointing to objects in the shop, Henry just recounted the plots of three or four Disney movies.
+- “Operation Mixtape” 🤦🏼‍♂️
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*e5Vyj4QzvlWPg1rghFXifg.gif)
+*Wince!*
+
+- Henry did the thing 🖋️ he said he’d never do. And now he’s once again “trying to destroy magic.”
+- Everyone in town is supported and enlivened by magic in some way! If he destroys it, they all die.
+- I’m cautiously optimistic that Regina will not make a heel turn. She’s grumpy, obviously and understandably, but she’s working with Emma to find Henry.
+- Oh good, it’s time for another round of “spot the Vancouver landmarks in ‘New York’!”
+- Zelena but good, I like it.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*BzNzOGN28_tLYl0QxWOCyQ.gif)
+*Good thing we still have a very powerful magic-user in the party.*
+
+- Oops! All sucked through the portal and back to… uh, somewhere?
+- New York is where he’d rather stay.
+- “Welcome to New York, it’ll be $15.” “You don’t need my $15.” “I don’t need your $15.”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*4IgQgYudouR7adPIPbSYdg.gif)
+*The Force has a strong influence on the weak-minded.*
+
+- (The tollbooth has been placed on a [subterranean ramp](https://goo.gl/maps/qpG6QX7FXBY4HBVr6) outside Vancouver’s Waterfront Station.)
+- ([Right behind Violet and Henry](https://goo.gl/maps/3dQ3bLFChpnFnGC28) is a great burger place named Vera’s, now sadly closed; to the right is my favorite pub in the world: [Six Acres](https://goo.gl/maps/Ue6AjR99VSxZPQL2A).)
+- Broken wand. “Do you have any duct tape?” I don’t like how they’re taking Zelena for granted.
+- Hmm, I think I’ve seen the guy in the brown jacket before. Is this a jail for magic users?
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*79SoTKaHYodSpnvUVxXdew.gif)
+*My character brief was “nervous scientist.” Nailed it.*
+
+- Very steampunk. I think the groundsman and the warden are Jekyll and Hyde.
+- I forgot Robin and Zelena-as-Marian were living here, in Neal’s old place. Who’s been paying the rent on this “New York” apartment?
+- Oh, a letter from Robin! 😭
+- This is a very powerful scene. “I hate doing good.”
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*xsUEtPwp4oqvvmwcRe6WYQ.gif)
+*I’m not crying you’re crying.*
+
+- (Also Regina’s outfit is 🔥🔥🔥)
+- The Rare Reading Room is all green screen.
+- Some stories from OUaT Volume II: Gulliver’s Travels, 20,000 Leagues Under The Sea, Don Quixote, Paul Bunyan… and the land where the heroes landed.
+- Jekyll and Hyde confirmed. And Poole, in the book, was Jekyll’s butler.
+- “This is a bad plan,” says David, who knows a bad plan when he comes up with one.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*nFIRP5ZhC727KeNzgLE7rA.gif)
+*No no it’s fine.*
+
+- (crash) “Oh!” That was needlessly destructive, Henry. You could have unlocked the case.
+- “All too easy.”
+- Hyde goes through more jackets that way.
+- The actor playing Hyde is very familiar: [Sam Witwer](https://www.imdb.com/name/nm1022429/).
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*8Ehm4GghXDM8BX6yx7xUVA.gif)
+*Sam has a really impressive voice-acting resume.*
+
+- Steampunkland looks beautiful! Kinda like Tomorrowland ’97 was supposed to look before the budgets were slashed.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*ikEidhJgOEmgrBg6r-0UTQ.gif)
+*Remember when the Observatron actually worked?*
+
+- Henry is ascribing a lot of conscious motivation to a natural force. The magic “wants” to do things? Does it take action?
+- Very swanky hotel. RumpleGold has good taste. I wonder if he’s getting Bonvoy points.
+- Rumple: I can show you the world. Shining, shimmering, splendid.
+- The portal took the box. And Rumple lost it because he always tries to save his power (the crystal) first.
+- How does Hyde know about Belle in the box? How in fact does Hyde seem to know all these details about our heroes?
+
+Next week: The season five finale! And then a four-week hiatus! During which time I will be in the frozen wasteland of A̶r̶e̶n̶d̶e̶l̶l̶e Antarctica!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*bJ6XA42ndEHCFUYHZGTQHQ.gif)
+*Not on the itinerary as far as I know.*

--- a/src/content/ouatrevisit/2023-02-07-ouatrevisit-s5e23.md
+++ b/src/content/ouatrevisit/2023-02-07-ouatrevisit-s5e23.md
@@ -1,0 +1,91 @@
+---
+title: "#OUaTrevisit: S5:E23"
+date: 2023-02-07
+description: "Welcome back to #OUaTrevisit! It’s Wednesday and we’re wrapping up season five. Don’t forget to check out Katie’s and Cindy’s posts too!"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s5-e23-205105c6299"
+---
+
+### #OUaTrevisit: S5:E23
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+Welcome back to The Land Without Magic, aka New York, which is actually Vancouver! It’s Wednesday night, and Cindy, Katie, and I are wrapping up #OnceUponATime season five. After this week, we’ll take a four-week hiatus and will return for season six on March 8th.
+
+#### S5:E23 An Untold Story
+
+“Emma and Regina race to find Henry before Gold can.”  
+Airdate: May 15, 2016
+
+- This episode’s slug barely touches the plot. But I’m not sure how I would have written it differently.
+- Of course, the “groundsman” does know precisely where the “warden” is.
+- A refuge… from the costuming department!
+- Somebody call the Ghostbusters to that hotel!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*DRzkgx8V2zrAosL3mMujFw.gif)
+*This building should be condemned.*
+
+- If the door is glowing with an unearthly, evil light, maybe don’t go in.
+- I didn’t have “gets a big tip and leaves safely” on that room service guy’s day.
+- A text from Granny! Everyone went through the portal! (“Again?”)
+- Regina is trying to convince Gold, but I’m not buying it.
+- Why didn’t Zelena’s blast affect Hyde?
+- Clever hacker key.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*T1bQAf3LyL5-HJmPUJMemg.gif)
+*Easy money.*
+
+- Oops, Emma, obviously he knows you’re there.
+- The Grail seems to work like the Hat.
+- That was disturbing!
+- Was that a magic Taser?
+- Don’t blame Henry for your nonsense, Gold.
+- Without magic, Gold should be limping again.
+- Does the crystal do anything without any magic?
+- Regina doesn’t like hearing that… but I’m betting Gold is wrong about her.
+- Hey, it’s the Dragon? Didn’t Burnham kill him a few seasons ago?
+- (This could explain why his daughter is so powerful…)
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*nATmuaS3bt_eYpyscYN4XQ.gif)
+
+- (This scene is in front of the [Vancouver Art Gallery](https://www.vanartgallery.bc.ca/).)
+- Hmm, that was probably the wrong phrasing. Gotta be careful with the wishing.
+- It is the rabbit!
+- Isn’t this Bill Murray’s end speech in Scrooged?
+- “See, I told you,” says the kid who broke it in the first place.
+- Wishes!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*FtZbq7kiRsEj2R1E3ZElmA.gif)
+*Wishes!*
+
+- Doesn’t Hyde still have the box though?
+- He didn’t make the world believe. He made around 37 Canadians believe.
+- I don’t get how Hyde has all this inside information. Unless he read the script.
+- Regina, alone on the roof, still trying to come to terms with herself. I like that Snow is trying to help: with booze.
+- Oh no, I think I know what they’re going to do. This was presaged by the Jekyll/Hyde story.
+- This is a terrible idea! They’ll split out powerful Evil Queen Regina and we’ll be left with weakened Good Regina.
+- “Act, Lana, act!”
+- Okay, she’s out, this is your chance! She won’t. Of course.
+- Huh. She did it! But I bet that won’t be the end of 100% Evil Queen.
+- How many people were in that little car?
+- Violet’s origin story is kind of silly, but her father was a renowned Deadite-killer.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*jI3QDw8MtV4yZvPD1mjVeA.gif)
+*Shop S-Mart.*
+
+- Gold’s got a Chrysler, it seats about twenty.
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*-YSEPH-_bRQoPbq5FIf_Cg.gif)
+*So hurry up and bring that jukebox money!*
+
+- Ugh. There’s no way the Evil Queen is actually gone, right? Restoring magic to Storybrooke is going to bring her back.
+- “Storybrooke is mine now.” What, just because you say so?
+- Evil Queen dust, obviously.
+- This is a war!
+
+![Reaction GIF from Once Upon a Time Season 5 recap](https://cdn-images-1.medium.com/max/800/1*e9nYLClLPMlaHub40fQZww.gif)
+
+- With a little bit of Evil Queen music just to drive the point home.
+- So, season six will be about Regina vs Regina. I’m here for it. Her inner battle is now on display.
+
+That’s it for season five! As noted above, we’re taking the next four weeks off and will resume #OUaTrevisit with season six, episodes one and two on Wednesday, March 8. Try to keep your dark sides under control until then!

--- a/src/content/ouatrevisit/2023-03-08-ouatrevisit-s6e12.md
+++ b/src/content/ouatrevisit/2023-03-08-ouatrevisit-s6e12.md
@@ -1,0 +1,147 @@
+---
+title: "#OUaTrevisit: S6:E1/2"
+date: 2023-03-08
+description: "We’re back at #OUaTrevisit after a month away, and on to season six, episodes one and two. What did Katie and Cindy and I think? Well…"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s6-e1-2-779fbf757f70"
+---
+
+### #OUaTrevisit: S6:E1/2
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+We’re back in Storybrooke after a month away. Let’s get to the Revisit!
+
+#### S6:E1 The Savior
+
+“Regina and Zelena embrace their newfound sisterhood.”  
+Airdate: September 25, 2016
+
+- Is that the magic carpet? Are we getting Aladdin? Is that Jafar shooting magical bolts?
+- IS THAT ODED FEHR??
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*buSL7eMCmvvz-sV0mKljLw.gif)
+*Any show is automatically improved by adding Oded Fehr.*
+
+- “It took becoming a hero for you to completely come apart.”
+- Awkward kissing. Is this a kissing movie?
+- Oh no, it’s a spy balloon! Wait, strike that, just a magic dirigible.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*rNQiuhE-OCbkkRk1-Lcitg.gif)
+*Scratch one Untold Story.*
+
+- Who is this jerk to walk up and claim the town for his own?
+- So, randos from another realm are coming in to wreak havoc. Again.
+- I can’t get through Jekyll’s speeches without falling asleep. And Hyde’s voice characterization is so over the top.
+- Emma! You know not to keep secrets!
+- Meanwhile, Extra Dark Rumple is on a quest. And why is he so CGI’d in the face?
+- That guy is a Metron if I’ve ever seen one.
+
+![Screenshot from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*-wBIG4rVgOiSH72udB6okw.jpeg)
+*A Metron at the Metreon. Photo illustration by me.*
+
+- Frazzled mom Zelena is funny in a seventies sitcom kind of way.
+- A magic Taser? (Looking back, I see I made the same point last month.)
+- I’m altering the deal.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*t9RJPoqe7XK6dma4t1_vAg.gif)
+*Deals with Rumple tend to be pretty one-sided.*
+
+- Emma’s hands are shaking; she’s lost the flow. Also, Charlie Cale seems to have a much better handle on the lie-detector superpower than Emma ever did.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*2FUoYWzNMxiRzT6jNmhIRQ.gif)
+*Ah, just one more thing…*
+
+- Archie! Pongo! We haven’t seen you in like three seasons!
+- Archie Cricket, wandering psychoanalyst.
+- No, show, you will not make me interested in grumbly voice Hyde.
+- “Follow the red bird,” what’s that about?’
+- Not the Red Room!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*u468IKCmtSTo-OXX5KvFWw.gif)
+*Where we’re from, the birds sing a pretty song.*
+
+- “Are you willing to lie to her?” That’s literally all he does, of course he’ll be willing.
+- Belle’s provincial-town costume is better than the first times we saw it back in the early seasons.
+- “I thought it would take weeks and weeks of battles and twists and turns” — so did we.
+- What’s wrong with Regina? Why is she rejecting Zelena?
+- Hook: “I could use some food and shelter right about now, by which I mean let’s make out.”
+- Emma: “I’m not avoiding you, I just want you to leave.”
+- Regina seems to have lost quite a bit of her power. I wonder if she’ll get it back.
+- Henry: “When a hero’s story is over, there’s a special place for them. And it’s now streaming on Disney+.”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*ZIHBM4uo0iu6-GbXxQwfnw.gif)
+*(Waiting for the next Mandalorian episode to drop)*
+
+- I’m not buying this guy, supposedly Belle/Rumple’s son, at all. Nope.
+- Is that the Apprentice’s wand that RumpleGold is wielding?
+- She was once an Oracle. Now she’s just a sales force.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*qbNGlgkB-q_XqCni3UjR_Q.gif)
+*Sorry*
+
+- Just rolled my eyes so hard at Mister Hyde and his dramatic pronouncing. I hope at least he’s only a half-season villain. He’s so one-note, even the other characters are already bored with him.
+- I love that Regina and Snow have figured it out between themselves, finally.
+- And now here’s Evil Regina with appletinis.
+
+#### S6:E2 A Bitter Draught
+
+“Emma divulges her ominous premonition to Archie.”  
+Airdate: October 2, 2016
+
+- The vault. Which is sealed with blood magic, meaning Evil Regina can waltz right in.
+- “Delightfully malevolent” sounds like a new Ben & Jerry’s flavor.
+- Why are the Three Musketeers coming from the Land of Untold Stories? Their story is definitely not untold.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*IRnnUXAmCrRsAy0-KAjLGw.gif)
+*Best version?*
+
+- Tepid applause at Regina’s speech.
+- MC: Monte Cristo.
+- Way to put a downer on the party, dude.
+- Regina’s Regency outfit here: 🔥
+- Thanks, Granny, for the eggy bread joke.
+- Emma’s vision-enemy shops at Dark One’s Warehouse.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*OQK4IXGeMk3hcSB3TvvMqQ.gif)
+*Until they turf him out, I guess.*
+
+- One thing with therapy is you kind of have to not leave the room.
+- Hey, it’s Leroy! Does something need announcing?
+- Edmond seems to have some insta-vanish power. But of course, the Count of Monte Cristo was historically a powerful wizard. 😐
+- Oh no, not again. The town line is walled off. Surprise!
+- Zelena protests so quickly. Regina should have noticed.
+- The Agrabahn Viper venom is what Evil Queenie used to kill Snow’s father, I think.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*JmMmiCr8W-d0UCDFxBtFIA.gif)
+*The CGI de-aging in this scene was distracting.*
+
+- I don’t remember Rumple putting a protection spell on the Charmings?
+- Evil Regina in seduction mode is…quite convincing. But what was the coin about?
+- Whatever, Edmond. “It’s your eyes again.” Not the best line ever, is all I’m saying.
+- Right, Rumple’s long-term plan — the plan of a clairvoyant — calls for Emma to be born and eventually become the Savior. We need to be reminded of this occasionally since the writers seem to only remember about once per season.
+- Mayor Regina sword-fighting in her business suit and sensible shoes.
+
+![Screenshot from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*5WESPwXhIabmnQ213wSVNg.jpeg)
+
+- “This is the way.”
+- The sword went right through his heart…or where it would be if he had one. I feel like this is not the end of Edmond.
+- Eh, killing an attacker in self-defense shouldn’t cause any darkness.
+- Too many secrets.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*tIAyJIbZI28REJ6f0XSGBQ.gif)
+*SeTec Astronomy*
+
+- Yes, I agree we’re suffering from sequelitis at this point, Henry.
+- Evil Regina as a babysitter is kind of sweet, actually.
+- I think Jennifer Morrison might have been pregnant during the filming of season six, just based on the shot framing and the blousy tops.
+
+Finally, as a bonus for those of you who waited patiently through our monthlong hiatus, I asked ChatGPT to review the first two episodes of season six. And this is what it said:
+
+> As an avid fan of the hit television series "Once Upon A Time," I was extremely disappointed by the lackluster start of season six in episodes one and two. After eagerly awaiting the return of my favorite characters, the sloppy writing and lack of coherent plot left me feeling underwhelmed and unsatisfied.
+>
+> One of the most disappointing aspects of these episodes was the lack of character development. Instead of building upon the rich history of our beloved heroes, the writers introduced a multitude of new characters without properly introducing or explaining them. This made it difficult to invest emotionally in the story, leaving me feeling detached from the plot.
+>
+> Additionally, the pacing of the episodes felt rushed and disjointed. The plot twists came too quickly and lacked the necessary build-up, leaving me feeling confused and disoriented. Overall, I was left feeling let down by the season six premiere of Once Upon A Time, and I hope that the show’s creators can work to recapture the magic that made this series so compelling in the first place.
+
+At this point, I’m almost willing to give ChatGPT the job of watching the rest. Almost.

--- a/src/content/ouatrevisit/2023-03-14-ouatrevisit-s6e34.md
+++ b/src/content/ouatrevisit/2023-03-14-ouatrevisit-s6e34.md
@@ -1,0 +1,119 @@
+---
+title: "#OUaTrevisit: S6:E3/4"
+date: 2023-03-14
+description: "In this week’s Once Upon A Time revisit: Our Long National Nightmare Is Over."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s6-e3-4-a0b231f24a11"
+---
+
+### #OUaTrevisit: S6:E3/4
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+In this week’s Once Upon A Time revisit: Our Long National Nightmare Is Over.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*V9xfrJnljI6zlzMhNbTJsA.gif)
+*Kids, ask your parents.*
+
+#### S6:E3 The Other Shoe
+
+“Emma, Hook, and Henry scramble to help Cinderella.”  
+Airdate: October 9, 2016
+
+- Been a while since we’ve seen Cinderella.
+- Regina’s lasagna looks pretty good actually.
+- I saw David Anders in the guest credits: Doctor Whale is back!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*Z25GExHc-XY9vQJd808g6w.gif)
+*Nobody talks about brain club.*
+
+- Killian playing with the little girl: ❤️
+- Wow, not cool (step)mom.
+- Gus! In his little waistcoat.
+- Dopey went off to get his Masters!
+- The mind has a strong effect on the body.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*frMCo_606GvyGpjxVIPswA.gif)
+*You don’t need to see my identification.*
+
+- Jekyll just dropped a sugar cube in his potion.
+- “I brought you more glass stuff!”
+- Using Cindy’s (blue) tennis shoe to find her, clever!
+- Free cheese!!
+- (Do you think he could be charming? … That name’s taken.)
+- A quick piece of business is what The Prince calls his bathroom.
+- Glass slipper to a glass chess set, nice transition.
+- Gold’s hair looks different somehow. (We later see him with a new ‘do; I suspect he’s wearing a wig in this episode.)
+- The show is trying to disguise Jared (Henry) Gillmore’s growth. He’s almost taller than Killian now.
+- Evil Queen’s blue dress!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*DDpwE7W4s4VKpQJnD7XCzg.gif)
+*It’s all worth it.*
+
+- Now, where did she send them? Somewhere with an empty road and no signs.
+- The quizzical look on Belle’s face is because she and David haven’t actually shared a scene that I can recall, anyway.
+- A mix tape. He made a mix tape.
+- Camilla? Clarissa? Callista?
+- [Lisa Banes](https://www.imdb.com/name/nm0051862/) played Lady Tremaine in season six.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*AURdNMAhQI2B3eR2uW3M8Q.gif)
+*“You look like a trash bin and have the education of my cat.”*
+
+- Royal glass blower.
+- C’mon, Savior, do something!
+- The Doctor has a fantastic car.
+- Doctors Jekyll and Frankenstein, LLC.
+- Lady Tremaine gets an appropriate sentence.
+- Snow is trying to convince David and, of course, he’ll agree now and rethink it later. Such a dumbass.
+- Seems like Evil Queen could have done that earlier. 🔗
+
+#### S6:E4 Strange Case
+
+“The Evil Queen and Hyde continue on their quest to steal.”  
+Airdate: October 16, 2016
+
+- Really, that’s all there is. “Quest to steal.” Even the slug writer has given up.
+- Looks like Mr. Gold’s hands are shaking just a bit.
+- Whoa, the hair! Robert Carlyle was filming [Trainspotting 2](https://www.imdb.com/title/tt2763304/) during OUaT season 6.
+- I don’t blame Gold for force-choking Hyde. But why didn’t Gold’s power work?
+- This will inevitably mean Gold teams up with the good guys again.
+- “I’m the Savior, not Romanian power lifter!”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*ZYOCbvWOtaJyBUti4CZp8g.gif)
+*I’m a doctor, not a … fill in the blank.*
+
+- Jekyll exposition…zzz…
+- “What’s so important I had to be pulled away from Scotch and cards?”
+- Rejected!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*VIkHrwhr1tn-rsXF4et8NA.gif)
+*Not in my scientist club!*
+
+- How did Rumple journey to this realm, anyway?
+- Today, in “dumb things done by mad scientists…”
+- Not cool, Gold. What a jerk.
+- “It’s always out of one prison and into another with her.”
+- More Leroy content, please!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*rKllqcvcfz6BeyzRq6oyUQ.gif)
+*I want a Leroy spinoff where he just tells people things.*
+
+- Mister Hyde, of course, because he wants to hide. If he was alone, we’d call him Mister Solo.
+- Nobody at the party cares about Hyde’s creepy red eyes?
+- “The mighty wall between chaos and calm!”
+- The difference is that Evil Queen was mocking, but Regina means it.
+- Extra red juice!
+- Red juice on the dagger should give Gold power over Hyde.
+- Who is Shirin? Is it Jasmine?
+- Whenever Jekyll is speaking I just want to ⏭ fast forward.
+- Oh, this isn’t going to end well for Mary.
+- A man unencumbered by social obligation. In other words, a psychopath. Cool cool.
+- Everyone is still calling him Hook. Even Emma!
+- Dangit. And now Hyde has the dagger.
+- Out the window. Saw that coming.
+- And one half of the separated person can’t live without the other. Does this mean the blessed end of this subplot?
+- Well, we’re not losing Lana Parilla. So obviously there will be another out for Regina.
+- Dark Rumple wanted to expunge his feelings for Belle. Creepy.
+- “You didn’t cut your hair for me, you cut it for Trainspotting.”
+- Oh good, threatening her will definitely work.
+- Aha! Does this mean we get more Oded Fehr as Jafar?

--- a/src/content/ouatrevisit/2023-03-23-ouatrevisit-s6e56.md
+++ b/src/content/ouatrevisit/2023-03-23-ouatrevisit-s6e56.md
@@ -1,0 +1,129 @@
+---
+title: "#OUaTrevisit: S6:E5/6"
+date: 2023-03-23
+description: "In this week’s pair of Once Upon A Time episodes, we’re hanging out with more people from the Land Of We Forgot We Have A Main Cast."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s6-e5-6-4cca5f116679"
+---
+
+### #OUaTrevisit: S6:E5/6
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+In this week’s pair of Once Upon A Time episodes, we’re hanging out with more people from the Land Of We Forgot We Have A Main Cast.
+
+#### S6:E5 Street Rats
+
+“Aladdin and Jasmine try to save their home from Jafar.”  
+Airdate: October 23, 2016
+
+- Wish noise!
+- Casting an Australian actor with a very pronounced Aussie accent as Aladdin is a choice, for sure.
+- Not the meet-cute I remember, but okay.
+- A little bit of “Street Rat” in the background music.
+- This is an ex-Oracle. The marks on her face seemed familiar though. Wasn’t that the poison Rumple used on Jekyll’s love interest?
+- “Hyde’s dead.” “Really? Then here’s everything you asked for.”
+- Emma’s superpower! 🍺🍺
+- “No, I just saw the movie.” Have all the Storybrooke residents made it a point to watch their movies? Do they wonder about all the movies that don’t have corresponding Storybrookians?
+- Aladdin was a Savior? That changes things.
+- Evil Regina does indeed seem like someone who could benefit from therapy.
+- Creepy fake Doctor Cricket!
+- I’m a fan of Zelena’s outfit in this scene.
+- You know, like “A Whole New World” and magic carpets?
+- A princess, stuck in a palace full of books. She’d probably get on well with Belle.
+- Gotta admit this Cave of Wonders entrance plaza is pretty impressive.
+- He should have tried _“Mellon”_.
+- Not helping, Killian and Henry!
+- A little bit of Indiana Jones and a bag of sand in this scene.
+- Did Aladdin just magic the collapsing walls?
+- I’m not buying something about Shireen/Jasmine’s story here. Seems too pat.
+- “We don’t keep secrets from each other,” says Mary Snow White Margaret about her husband Prince David Charming, who both have kept secrets enough from each other to keep this series going for six seasons to date.
+- Doctor Archie bouncing the baby is kinda cute.
+- So wait, Evil Regina, hated and feared by literally everyone, just goes to the salon? Does she make a reservation or just waltz in and toad-ify the other customers?
+- The blocking in this scene is conspicuously not showing the faces of the stylists, but the woman working on Evil Regina is dressed like Briar Rose.
+- She said it!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*tXFzcZhctzE0ESzvYWiiow.gif)
+_Vader said it, too._
+
+- I cannot get over having Oded Fehr cast as Jafar.
+- Maybe Evil Regina’s stylist has a pair of those Fate Shears?
+- Nice work, Savior Aladdin. Didn’t have to wish on a Genie or anything.
+- According to the subtitles, Emma was reacting to “magical whooshing.”
+- How did Regina’s spell linking magic to magic link Emma to a skeleton? Surely long-dead bones don’t still have Savior magic.
+- Ah, not dead after all. And apparently, he’s had the Savior Shakes too.
+- “I can show you the world.” “Oh, I can’t, I have to wash my cat.”
+- Scoundrel, your kinda guy.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*P9DVaSLg8-nuXcOCPdo4dg.gif)
+_Jasmine happens to like nice men._
+
+- Jafar quietly magicking the shears back to Aladdin is pretty clever.
+- If Emma uses the shears, Storybrooke will fall. I assume.
+- Oops, he’s not a Savior anymore. What will we do? Send Emma to Agrabah? Another half-season side quest?
+- (Dearie)
+- “We can protect you. And we can protect this town,” says David, who obviously hasn’t watched the previous five seasons.
+- So we’re gonna take the thing that could remove Emma’s power permanently and just… throw them in the water? I’m sure Evil Regina or RumpleGold will never find them. … Or, he never threw them away at all.
+
+#### S6:E6 Dark Waters
+
+“Hook is taken captive by the mysterious Captain Nemo.”  
+Airdate: October 30, 2016
+
+- If Aladdin used the shears, and they removed his Savior magic but didn’t kill him in some horribly obvious way, that means Jafar was actually telling him the truth.
+- Okay, who is playing Captain Nemo? A very familiar voice. … It’s [Faran Tahir](https://www.imdb.com/name/nm0846687/), who I recognize from Warehouse 13.
+- That’s no Narwhal.
+- Should be perfectly safe here in this unlocked toolbox in this unlocked garage.
+- Was that a sea monster? Mister Baxter, check the air pressure.
+- So Regina and Zelena are no longer on good terms? How sad.
+- Is MM including Regina in her family? Kinda love that.
+- Agrabah. City of mystery, of enchantment, and the finest merchandise on sale today!
+- “Green hook” (wince) Shouldn’t Emma’s superpower have nailed Killian’s lie?
+- “So, what’s for breakfast?” “It’s Jasmine.” “Jasmine’s for breakfast?”
+- Evil Queen tossed the apple over her shoulder: perfect.
+- You have to ask yourself one tiny question.
+- Maybe don’t go through the stolen wallet right there in front of the car you just broke into. I thought he was supposed to be some kind of master thief.
+- “Traded in the carpet for a Miata?” Zoom zoom.
+- Dark Curse Hook = guyliner city.
+- The Nemo crew uniforms look awfully Caladan.
+
+![Screenshot from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*r9zAiQaMF75pcT6hVALDNg.jpeg)
+_The Kraken is the spice, and the spice is the Kraken._
+
+- Between Oded Fehr and Faran Tahir, very strong casting this season!
+- Enchanted harpoon?
+- I’m kind of fascinated by Captain Hook and Captain Nemo. And the Nautilus is gorgeous.
+- Who was brought into the hospital? Probably Nemo?
+- I’m a little confused about Belle’s pregnancy timing here, but whatever.
+- Ah, the old Wookiee prisoner gag. When Henry said “never mind, alternate universe”, was he making a subtle joke about Legends canon?
+- Those diving suits!
+- “I think the pressure’s getting to you” as we’re underwater.
+- Oh no, the Rancor! I mean the Kraken!
+- “The Shears of Destiny”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*JgNBMpH2zx4DNvQDA8Zpcg.gif)
+_This is the level that never ends…_
+
+- Evil Regina’s little disgusted look as Rumple walks out.
+- The lesson Emma is trying to impart here is not really helpful!
+- I know what happened to Agrabah. Jafar took over, people were sad, and everything was lit somewhat redder.
+- Meanwhile, Killian and Henry are just hanging out on the Nautilus.
+- An innocent orphan boy, huh? I’m sure it’s not Nemo’s first mate, who was just arguing with Killian.
+- The key opens a door to a place called The Mysterious Island. Here’s the guidebook.
+
+![Screenshot from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*XRCMtB4W7lS8riCVFNWn4Q.jpeg)
+_I’m pretty sure Allan Quatermain hangs out there._
+
+- “Iron tin”?
+- Right, they’re trapped. Except, Henry, being the Author, could just write them a way out. Beware of introducing superpowers, because you then have to justify not using them in every subsequent story.
+- Killian doesn’t appear to be donning a diving suit. I’m not surprised.
+- So, how does Nemo survive?
+- Good idea, treasure chests sunk to the bottom are definitely never recovered.
+- Aladdin, there’s more that I need to tell you. 👼🏼
+- Doctor Whale, who does not appear in this episode.
+- We don’t actually find out what happened to Nemo, who beat him up by the mine entrance or anything.
+- “Everything that happened today was my fault.” EVERYTHING?
+- Evil Regina’s evening gown: 🔥
+- Belle almost walked in just as E.Q. and RumpleGold are making out.
+- A few underwater creatures who owe her a favor?
+- Snow White’s heart. Of course.

--- a/src/content/ouatrevisit/2023-03-29-ouatrevisit-s6e78.md
+++ b/src/content/ouatrevisit/2023-03-29-ouatrevisit-s6e78.md
@@ -1,0 +1,171 @@
+---
+title: "#OUaTrevisit: S6:E7/8"
+date: 2023-03-29
+description: "This week the showrunners remembered we’re in season six of a long-running ensemble drama, not an anthology of brand-new stories!"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s6-e7-8-eb030547a24c"
+---
+
+### #OUaTrevisit: S6:E7/8
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+This week: The showrunners remembered we’re in season six of a long-running ensemble drama, not an anthology of brand-new stories with brand-new randos every week! In other words, apart from a side quest featuring the World’s Worst Thief, we got back to the stuff we care about.
+
+Also: Hmm, first two weeks of November 2016. Most of that time is completely blank in my memory for some reason.
+
+#### S6:E7 Heartless
+
+“The Evil Queen finally gets her ultimate revenge.”  
+Airdate**:** November 6, 2016
+
+- No “previously on”, just Snow and EQ in the woods.
+- EQ is extra creepy tonight!
+- “What do you think? Something terrible.”
+- I feel like Zelena is not totally into Evil Regina.
+- Oh, I don’t want to know what DarkRumple and Evil Regina are doing.
+- It’s a family “hairloom”, according to Snow’s odd pronunciation.
+- Suddenly David has a doggo! Whose name is Wilby! I love Wilby!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*gr9ggBQfO1R8DJ6KEytGOA.gif)
+*Wilby!*
+
+- Oh hi, Mom Charming.
+- Flap, flap, flap.
+- She needs an allied nation, maybe she could go to Arendelle. (I know, too early in the timeline.)
+- Snow and Charming are separately heading to the same town, but they haven’t canonically met yet.
+- This is now a Wilby fan page. That is all.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*A068kWUfnRRAL4t7xvvQJg.gif)
+*Wilby!*
+
+- I don’t trust this guy, not at all.
+- It’s a medieval murder van. Great.
+- Blue Fairy’s dress is just not suitable for, you know, walking. She looks like a parade jellyfish.
+- “I’ve looked through all my books, but there’s nothing.” “Well, keep looking.”
+- “I came as soon as I could!” Our team is just playing Superheroes now.
+
+*Thank god you’re here, jellyfish-dress-lady!*
+
+- Magic powerful enough to imprison the EQ, in a small tree! I sure hope it isn’t the one Regina poured the water on earlier.
+- The group wince was just perfect.
+- I see some green, Zelena.
+- “You need to calm down.”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*Jrog9fL9zsS5lNSKcY0W8w.gif)
+*(Seattle, July 22nd)*
+
+- Sure, Prince Dumbass, just take a giant slug of what the guy with the murder wagon offers.
+- Get him, Wilby!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*YK6LM7KPp9pav8bhzKGbxQ.gif)
+*Wilby!*
+
+- The Woodsman is actually supposed to kill Snow, right?
+- “It’s a trap door.” Thank you, Captain Obvious.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*GMmO396L8DzpWg6JzDB1Ng.gif)
+*I could do this costume.*
+
+- Is it the best idea to have Emma and Hook pack up all of Regina’s stuff? Or we’ll just hang out here in the vault and tell stories.
+- Remember who you are!
+- We know he doesn’t break the lock because this isn’t how they meet.
+- Flashbacks!
+- WOW at EQ’s “Rage against the dying of the light.” Lana is having a blast.
+- Ugh, run through with his own axe handle.
+- “As you wish.”
+- This split scene. Does somebody want to build a snowman?
+- Ah, this is when Snow becomes a bandit. And it turns out she and David met once before after all.
+- What rabbit Snow and David will pull out of their hats this time?
+- The little bit of darkness in the hearts from when Snow killed Cora.
+- Okay? I’m not sure what EQ expects to gain from that. It seems more like a Bond villain time-waster. “I won’t kill them because I want them to suffer more!”
+- Blah blah, Belle hates Rumple now, snore.
+- To the woods!
+- Back in the glass coffin. Wonder what the trick is here.
+- Oh, only one of them can be awake at a time. Funny.
+
+#### S6:E8 I’ll Be Your Mirror
+
+“Emma and Regina plan to trap the Evil Queen.”  
+Airdate**:** November 13, 2016
+
+- Their last plan worked so well, let’s try again.
+- Apparently, this wake/sleep curse is also the plot of Ladyhawke, which somehow I’ve never seen.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*oLuoPXcJ3nOi6-65XnZgdg.gif)
+*Rutger Hauer, Michelle Pfeiffer, Matthew Broderick.*
+
+- Creepy! Watching through the mirror!
+- And now, a musical montage.
+- But they’re gonna get aggravated really quickly, aren’t they?
+- Didn’t Evil Regina kill The Dragon though?
+- Stood up for John Hughes movie night twice? Rough.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*nTJHMV6OghkHq90-6fJaBQ.gif)
+*This explains Evil Regina.*
+
+- Oops! Wrong mirror.
+- Now we’re in the Land of Mirrors. And every mirror is one-way.
+- Dramatic shadow!
+- Tricky fake voicemail.
+- Hmm, somebody is not going to buy this. But who?
+- “He’s the Dark One, he’s always up to something.”
+- Are Belle are Zelena really teaming up here?
+- The height difference makes for funny scene blocking.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*yWZmvqF37arNRs3wmKoAjw.gif)
+*They should have had Belle stand on a box.*
+
+- I like snarky Zelena a lot more than whiny Zelena.
+- “Never thought I’d see you in a pantsuit, Your Majesty.”
+- Of course, Gold happens to have this random mythical hammer in his cabinet.
+- Love can be a weakness, but it can also be a battlefield.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*1yfsciPvZeLJPLakxqg2Pw.gif)
+*No one can tell us we’re wrong.*
+
+- Uh, Killian would be dead.
+- That’s where Henry would be taking Violet, if she showed, which apparently she isn’t.
+- “She’s a commoner” ought to be a red flag, but it wasn’t.
+- But telling Henry to stand up straight: what a giveaway!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*OghWKEfrG0TMaP22IoKB1g.gif)
+*Bum!*
+
+- sEQ has a little bit of a blind spot where Henry is concerned.
+- Dragon!
+- A back door! Don’t give away our secrets!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*goqDWJZW89cjvJywjR2OpQ.gif)
+*Mister Potato Head! Back doors are not secrets!*
+
+- I’m really not super impressed with the Master Thief.
+- Abu! (“Thanks, monkey.”)
+- Whatever happened to Moff Sidney, anyway?
+- “It’s not like leaving a voicemail, Henry.”
+- Not the old creaking oak tree!
+- “I’ll never join you!”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*O1H4MXArKHaef4gqODJEFg.gif)
+*Until the next movie!*
+
+- Oh right, EQ took Dragon’s heart.
+- That’s a pretty fancy dragon.
+- So EQ is trying to win over Henry by…killing his moms? Except Regina dying would also kill EQ, so not too smart.
+- I love the Regina/Emma alliance.
+- Nice job Henry!! And he grabbed the Dragon’s heart, too.
+- The lamp! But who is inside? (Is it Sidney? Wasn’t Sidney a genie at one point?)
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*_jE1hkooUEXJ2-D3rwdCSA.gif)
+*No wishing for more wishes.*
+
+- I had forgotten about Zelena saving Gold in the hospital. And didn’t realize it linked them together.
+- Nice of Granny to let Henry use the place.
+- Violet took a little too much from The Breakfast Club.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*8IB5q8NwlnFUs75hrqXTPw.gif)
+*We’re all pretty bizarre. Some of us are just better at hiding it, that’s all.*
+
+- Evil Regina’s evening gown: 🔥
+- “You know me, I’ll do anything.”
+- I don’t like these two together. It’s unpleasant. Which is probably how I’m supposed to feel.

--- a/src/content/ouatrevisit/2023-04-04-ouatrevisit-s6e910.md
+++ b/src/content/ouatrevisit/2023-04-04-ouatrevisit-s6e910.md
@@ -1,0 +1,91 @@
+---
+title: "#OUaTrevisit: S6:E9/10"
+date: 2023-04-04
+description: "The Evil Queen sneers and glowers, The Dark One growls and threatens, and Our Heroes make bold statements, but nothing really happens."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s6-e9-10-4349a31cee8e"
+---
+
+### #OUaTrevisit: S6:E9/10
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+In this week’s #OUaTrevisit #OnceUponATime episodes, it’s clear that the writers were mostly spinning their wheels, trying to keep several plotlines alive while not making much progress. The Evil Queen sneers and glowers, The Dark One growls and threatens, and Our Heroes make bold statements, but nothing really happens.
+
+#### S6:E9 Changelings
+
+“Gold tells the Evil Queen she must kill Zelena.”  
+Airdate: November 27, 2016
+
+- “Wingless glowworm”
+- Both of these people are lying to each other.
+- Why would he announce it? Because he’s the villain.
+- “Manual on Defeating the Dark One” is filed under M for Manual or D for Defeating? Or P for Plot?
+- No way is that actually Belle’s son.
+- (Dearie)
+- Squid ink! That always works.
+- Maybe you could! If Rumple doesn’t do some horrible baby sacrifice magic first.
+- EQ’s fit today is straight out of an 80s dance club, and I love it.
+- That’s a bold move by Regina. Using her own heart to threaten EQ.
+- How long will the squid ink last? Not too long. And then he just creepily appears behind Belle.
+- Who was the Black Fairy? Have we seen her before?
+- Regina just acknowledged she’s a hero. I’m here for it.
+- Phenomenal cosmic powers, itty bitty living space.
+- EQ is just surprisingly ineffective overall.
+- Flap, flap, flap.
+- We have to hurry! But first, exposition!
+- Is that chamomile decaf?
+- Oh, the tea had the pregnancy speedup powder in it! (It wasn’t decaf)
+- Huh. Rumple is the Black Fairy’s son? That’s quite a dysfunctional family.
+- (The Black Fairy played by [Jaime Murray](https://www.imdb.com/name/nm1444665/), who I remember from Warehouse 13)
+- I wouldn’t think the Dark One could enter the house of the Fairies, even with the dagger.
+- What is definitely-not-Belle’s-son suggesting here? Just say what you mean!
+- Oops, he did get in. And actually tried the “our son” gambit.
+- I had forgotten that Zelena killed Baelfire/Neal, or at least was the reason he died.
+- This is not useful, Gold!
+- So, who do we think is under the hood?
+
+#### S6:E10 Wish You Were Here
+
+“The Heroes uncover a weapon that can defeat the Queen.”  
+Airdate: December 4, 2016
+
+- EQ hanging out at Robin’s grave is just mean.
+- Whoa. The sword can hurt EQ without affecting Regina!
+- Leroy has news!
+- Seems like actual murder would be a little out of Emma’s range though. But she did kill Cruella!
+- Oh here’s Aladdin-as-Genie. Fun.
+- Can the Genie do that? Retcon the entire series? I guess so.
+- If Emma was never the Savior then the OG EQ never cast her curse?
+- “With the Queen defeated, all of that was avoided.”
+- One of the servants obviously left the sword under her bed after cleaning the Armory. Naturally. Like you do.
+- Sir Neal!
+- “This family is done fighting.”
+- Belle’s and Gold’s hair together should show the son’s location, but he’s “elsewhere.”
+- I do like an Appletini.
+- “Ew.” — Aladdin Genie.
+- Clever! So clever!
+- Except umm, people are going to think she’s the Evil Evil Queen. Oops.
+- Emma was humming “Someday my Prince will come.”
+- “You’re so old!”
+- Uh oh, Sheriff Dumbass has a plan.
+- How did Rumple survive decades in an abandoned dungeon?
+- I don’t think I like this plan, Regina. If you’re in recovery, you shouldn’t go back to the things you did before.
+- What cell carrier serves Storybrooke? Are those old flip phones off-contract?
+- I love the queen’s speedwalk.
+- David was just distracting Killian and Jasmine.
+- A snake, am I? Perhaps you’d like to see how snakelike I can be? Or not.
+- That’s kind of not really a great wish. “Exactly what she deserves” is not specific enough. Unless there’s a catch. I’m sure there’s a catch.
+- Uh. What the hell, Emma? 🗝
+- Oops, squeezed too hard. 💔
+- Aha, it’s Sir Henry! Which is not according to the story.
+- Very dark.
+- Portal! (Leroy!)
+- This must be the Extra Dark One who kills Emma. And turned EQ into a snake.
+- Fake Rumple is funny.
+- “Do you trust me?” 🧞
+- Oh, I think I may have a clue about the identity of the Extra Extra Dark One.
+- “Big trouble!” — Leroy
+- Uh-huh, thought so. Belle & Gold’s son, or the person who says he is.
+- Hi Robin! Nice hair.
+- Oh no, waited too long.

--- a/src/content/ouatrevisit/2023-04-11-ouatrevisit-s6e1112.md
+++ b/src/content/ouatrevisit/2023-04-11-ouatrevisit-s6e1112.md
@@ -1,0 +1,139 @@
+---
+title: "#OUaTrevisit: S6:E11/12"
+date: 2023-04-11
+description: "This week in #OUaTrevisit, Regina does that thing where you KNOW you shouldn’t look but you just HAVE to look anyway. How’d that work out?"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s6-e11-12-5827535475"
+---
+
+### #OUaTrevisit: S6:E11/12
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+This week in our weekly #OnceUponATime revisit, Regina does that thing where you KNOW you shouldn’t look but you just HAVE to look anyway. How’d that work out? Take a guess.
+
+#### S6:E11 Tougher Than The Rest
+
+“Regina explores what Robin’s life is like without her.”  
+Airdate: March 5, 2017
+
+- Did we really need to do this with Robin 2.0? Hasn’t Regina suffered enough heartbreak?
+- Oh hi Young Emma, why are we desecrating books?
+- Young August? We know he’s been keeping an eye on Emma since they arrived.
+- (Her name is actually Emma Duck)
+- Good thing they didn’t call her Emma Solo, ’cause she was alone.
+- Thank you, Prince Exposition.
+- What did Emma see in the driftwood? (It took me some time to realize that Emma saw the driftwood and thought wood -> Pinocchio -> August. Didn’t make sense at first.)
+- David’s right: “Give the Evil Queen what she deserves” was a particularly stupid wish. At least so far.
+- So I guess this is actually Belle and Rumple’s son.
+- I don’t think that’s how it works, bro. It’s not like killing the Dark One and taking the Dark Dagger.
+- Hey, it’s grown up August! Nice to see him.
+- Hi Tink!
+- Regina keeps forgetting that in this reality, she’s still the Evil Queen. It’s silly. On the other hand, it’s interesting that the various tavern-dwellers and townspeople immediately place Regina as “Evil Queen” even though she’s in a pretty sharp business suit and jacket.
+- I like how this Robin is clearly not fazed by Regina.
+- Oops, hi, Nottingham. With an anti-magic cuff.
+- August has inherited a special, powerful tool from his father.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*FP_lbjAmJfPi6NkCM6GHcQ.gif)
+*From a certain point of view, anyway.*
+
+- Grotty Hook. Extra grotty!
+- Gideon shops at The Name of the Robes.
+- “Princess Enya”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*bcUVW4LhZxMBj7pFzO5k6w.gif)
+*Seems like Hook ought to just Sail Away.*
+
+- Emma is now doing magic without a second thought. But she can’t fix August’s chisel?
+- “You failed with flying colors!” I’m going to appropriate that line.
+- “Give to the poor, why the hell would I do that?”
+- Oh good, it’s Rumple, said no one ever.
+- This is actually a really good outfit on Belle.
+- “It’s been a while since I had a good flay.”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*3l7wdAopwEkt9a3RfgNGDw.gif)
+*Define “good” in this context?*
+
+- You’re a folk hero and in a relationship with the Queen, not bad. But, also, dead.
+- Since this whole realm is a dream, a fantasy, or maybe a wish, it seems like Regina is really just using this version of Robin for therapy. Which is not a terrible idea.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*tGrexNLftObYVOTtTad0XA.gif)
+*A Dream is a Wish your travel agent makes.*
+
+- “I guess I’ve always liked swans.”
+- There is no fate but what we make for ourselves.
+- Too bad we had to take down this thousand-year-old tree to make it happen, yeah?
+- When they leave, this world ends, right?
+- “I’m in.”
+- So… did it work?
+- Ugh, Regina never catches a break. But wait! It did work!
+- Gonna be a little awkward for everyone who went to Robin’s funeral.
+- My name is Gideon. I bake cookies. Get in line now.
+
+![Screenshot from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*KD_a_5sN4o6YTlJldp5KWg.jpeg)
+*No cookie!*
+
+- She’s not wearing the same thing as in her vision. So it won’t happen today.
+- August is writing about Pleasure Island. 😭
+- Another good outfit on Belle. Did the show change costume designers this year?
+- Rumple is lying, of course.
+- Man, we just had that clock fixed! This is why we can’t have nice things.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*6SINNSsp6jgik4iHACzu6w.gif)
+*(July 23, Seattle #ErasTour)*
+
+#### S6:E12 Murder Most Foul
+
+“Regina acclimates Robin to life in Storybrooke.”  
+Airdate: March 12, 2017
+
+- How does this work for Robin 2.0? Does he just take over the Merry Men (or did they leave?) What about Roland? What about little Robin? Can he reactivate Robin 1.0’s cell plan?
+- Oh, right, yet another one of David’s terrible ideas.
+- “David and James” in case you weren’t clear on exactly who these people are.
+- That’s the coin Dad always carried.
+- Rude, David! That’s your future son-in-law you’re insulting.
+- I guess Ferris Wheel in the opening sequence represents Pleasure Island. Fine, episode, rip my heart out.
+- “I once kissed David’s twin, trust me, a world of difference.”
+- I’m all in on the Snow and Regina coffee club.
+- Oh hi, Doctor Hopper!
+- They’ve moved on from written notes to video chat. Next it’ll be TikTok.
+- I don’t actually care about Dad’s story.
+- Oh hi, King George! Everyone who’s anyone is coming back this season.
+- Uh oh. David has a conspiracy board. How do I get a conspiracy board?
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*OCgdqmYbVNcu1Diw_6AmMg.gif)
+*Dedicated a whole wall of my home office to this.*
+
+- Oh look, David’s just being a jerk again.
+- Zelena overreacting? But that never happens.
+- “I know someplace where we can fix your hand” but Regina could of course just wave her hand.
+- Uh, wow, Rumple just casually has the Golden Fleece?
+- “Not much of a negotiator, are you?”
+- One hair off his head. That’s potentially useful for Rumple.
+- A land built from temptation…that could only be Pleasure Island!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*4WsV1yX639nAtXyTLlabLw.gif)
+*Yeah, I still miss it.*
+
+- Huh. Rumple actually did him a favor.
+- Emma’s superpower. Drink!
+- Eye roll at David stealing stuff from Emma. And at Hook lying to Emma.
+- Regina wants so badly for Robin 2.0 to be hers. But she knows it isn’t, especially when she kisses him.
+- Casting a spell is definitely going to go well for these two.
+- #Kungaloosh 😭
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*Dw_i2KPvAeVHlkXMPf70eA.gif)
+
+- Oh hi, Pinocchio!
+- The nose knows.
+- Talking to August was actually pretty smart on the part of David and Killian.
+- Ah, this is not going to end well for Dad.
+- King George straight-up orders Dad’s murder. Damn.
+- Why is the King in jail in Storybrooke? Did we know about that?
+- Sigh. This is just dumb on David’s part, like everything else he does.
+- Robin 2.0 stole something out of Regina’s trunk. Have we seen that before this week?
+- Oh no! Did Hook kill Dad?? Sigh. It’s not in August’s pages, but Killian knows he did it. Maybe he didn’t make the connection to David until just now?
+- Can you really marry the granddaughter of the man you killed? I guess if this were on HBO, maybe.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*y-4DoqDNEbm7Zc-F2OymPA.gif)
+*It’s funny to realize that OUaT ran concurrently with GoT for several years.*

--- a/src/content/ouatrevisit/2023-04-18-ouatrevisit-s6e1314.md
+++ b/src/content/ouatrevisit/2023-04-18-ouatrevisit-s6e1314.md
@@ -1,0 +1,136 @@
+---
+title: "#OUaTrevisit: S6:E13/14"
+date: 2023-04-18
+description: "We’re well into S6, and thankfully the writers have abandoned the random new side-stories introduced at the beginning of the season."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s6-e13-14-3b095a36b6ca"
+---
+
+### #OUaTrevisit: S6:E13/14
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+We’re well into season six now, and thankfully the writers have abandoned the random new side-stories introduced at the beginning of the season in favor of deeper explorations of our familiar characters.
+
+In particular, I love Regina’s continuing journey from Evil Queen to, you know, a complicated, conflicted person who is nonetheless trying to do the right thing.
+
+#### S6:E13 Ill-Boding Patterns
+
+“Gold takes action to protect Gideon from dark magic.”  
+Airdate: March 19, 2017
+
+- Previously, R2 stole something from Regina but we don’t know what it was.
+- Just, ya know, hanging out in camp while apparently, the battle is twenty feet away.
+- Wait, Beowulf? Really? Does that imply a Grendel?
+- “Hrunting”
+- Wilhelm!
+- I feel like this war would be fought with distance weapons, not hand-to-hand.
+- Hmm. Rumple joined the battle. Unexpected.
+- “A little early for rum, isn’t it?” It’s Killian-o’clock somewhere.
+- Ah, he didn’t know until he saw August’s pages that the man he killed was David’s father.
+- Emma might forgive him. David won’t. How long did it take Tony Stark to forgive Bucky? But Killian wasn’t brainwashed…
+- I guess the Emma-killing sword was originally Hrunting.
+- Oops, different Young Bae actor.
+- Everyone knows about Dark Rumple. Were they surprised?
+- “Why don’t I meet you at your manse tonight?” Points for “manse”.
+- Hey, the clock face was fixed.
+- Once you travel down that dark path, forever will it … I don’t remember the rest.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*JDq_0G9J73w97h-SMlFwvA.gif)
+*When nine hundred years old you reach, look as good you will not!*
+
+- Who are Gideon’s people? He hasn’t mentioned being a leader back in Black Fairy Land.
+- This is Beowulf and Grendel but it’s also Blazing Saddles. We hate you and want you to leave, but come crying to you when something terrible comes to town.
+- “This little munchkin went to see the Wizard.”
+- Why is there a protection spell around the town again?
+- R2 is mistaken: Zelena could leave any time she wants because she is a powerful magic-user.
+- Did people who lived in hovels call them hovels?
+- Usually, when Rumple gives the dagger to someone, it’s fake.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*AgXgOtwYU0qJ54k5dIEnqA.gif)
+*And Vreenak would know!*
+
+- Now both timelines feature RumpleGold’s son holding the dagger.
+- There is no Grendel, it was always Beowulf. Nice twist.
+- Gideon’s “destiny” is very confusing.
+- You’d think that after so long, Gold would have come up with a defense against being controlled by the dagger.
+- “Pet snake?” “She’s practically family!”
+- Everyone with the hats. It’s like Ascot Opening Day around here.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*qlXhDp60z5ngBHI9vYffdA.gif)
+*Move yer bloomin’ arse!*
+
+- Clever Bae! Grabbed the dagger from Beowulf.
+- Aw, Bae went too far that time. Can’t unsee that.
+- I would not like it if anyone kills Blue.
+- “I know what I have to do, but I don’t know if I have the strength to do it.”
+- Taking the sword that Blue died to reforge counts as touching the darkness. Darkness is fungible.
+- “What kind of tea is this?” Nothing changes.
+- Ugh, we’re back to the m-word again. C’mon, writers, find a different word.
+- (So Blue isn’t dead?) No Belle, really?
+- Liquid courage. Good luck, dude.
+- Oh, and she’s totally misinterpreting what he was going to say, of course. 💍
+- Okay, but the issue of David’s father is going to have to be resolved eventually.
+- “Okay, let’s go with that then.” Love you, Zelena.
+- Uh oh, snake on the loose!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*0yfSJDYsQRYy3f0BnXOg6g.gif)
+*Watch out, there are big steps.*
+
+- This EQ outfit is amazing.
+- “I don’t care if there are seven of you!”
+
+#### S6:E14 Page 23
+
+“Regina faces off against the Evil Queen.”  
+Airdate: March 26, 2017
+
+- Oh, bother.
+- Hi Dad!
+- Spotted in the guest cast: Rose McIver! Tink!!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*et5rpRpprVMchQacouu0Mw.gif)
+
+- Also: Faran Tahir. I guess Nemo is back too.
+- Uh, randomly snapping your minion’s neck is not a great way to inspire loyalty in your troops.
+- I thought they hadn’t spoken between the night at the tavern and when they met again on Pan’s Island.
+- “Excuse me, I sleep on hay! Which is on dirt.”
+- They’re gonna wait a while to plan the wedding, because plot.
+- I love how Regina just Kramers into the loft.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*b0vImbqqvC9XeuhCtpWMNg.gif)
+*Hey Jerry!*
+
+- Zelena goes girly over Emma’s ring!
+- “Mortal coil” snake joke.
+- The shears. EQ can separate herself from Regina.
+- It…could…work!
+- Nemo!
+- “Guilt can be as corrosive to the soul as revenge.”
+- EQ can’t use the Author’s pen. But I guess she can stop Henry from using it. Funny how the writers have mostly forgotten about it.
+- One thing this show has always done well is the quick-cut transition.
+- Side quest! Let’s go steal a powerful object.
+- Team Emma/Snow/Regina always.
+- Enchanted ropes 😂
+- She should have mimicked R2’s accent at “stand a chance.”
+- Dripping with Light Magic! And confetti.
+- Huh. Bravo Emma for accepting Killian. Though maybe give him a chance to get a word in before handing back the ring.
+- Blah blah blah, Dad.
+- “It’s always about revenge with us, isn’t it.”
+- They cut the lines. Now what? Now it’s time to swordfight in formal clothes!
+- Who does Evil Regina actually hate most? Yeah, I think we know.
+- Apples!
+- Okay, wow, this scene between Regina and EQ is very powerful.
+- That’s the Apprentice’s wand if you recall. Opens portals. Very useful item.
+- Where can a reformed EQ get a fresh start?
+- It surprises me to hear Snow say “Not everyone is redeemable.” That’s the exact opposite of what she believes!
+- Henry now has three moms.
+- Where do we think she went?
+- Oh, we’re back at the tavern, with R2.
+- She’s not the EQ here, she’s just a lady in a dramatic dress. This realm’s Snow and David were murdered and the EQ was banished, but maybe everyone forgot. Or perhaps she’s behind a glamour.
+- “For the first time in forever…”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*KDcGyOXKEyFqdIBEiKeLjg.gif)
+
+- Here’s Snow setting herself up to be terribly conflicted when she finds out about Hook killing David’s Dad but “love can save even the darkest souls.”
+- But suddenly something happened! Oh no! Now we’re off on another side quest!

--- a/src/content/ouatrevisit/2023-04-25-ouatrevisit-s6e1516.md
+++ b/src/content/ouatrevisit/2023-04-25-ouatrevisit-s6e1516.md
@@ -1,0 +1,184 @@
+---
+title: "#OUaTrevisit: S6:E15/16"
+date: 2023-04-25
+description: "Last weekend was a (very rare) in-person meet for the Revisit team! Naturally, we embarked on a treacherous voyage to another land."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s6-e15-16-9966a1c48bac"
+---
+
+### #OUaTrevisit: S6:E15/16
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+A couple of fun episodes featuring the return of the Aladdin/Jasmine/Jafar storyline, and more gleeful scene-chewing by the Black Fairy! We’re getting close to the end of season six. Who will survive, and whose stories will end?
+
+Also, this past weekend was another (very rare) in-person meet for the Revisit team! Naturally, we embarked on a treacherous voyage to another land…
+
+![Screenshot from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*pVCcWeuRbqczE7u6iXhPLw.jpeg)
+*Front to back: Jen, Cindy, Cindy’s husband, me, Katie, a single rider.*
+
+#### S6:E15 A Wondrous Place
+
+“Hook is trapped in another realm with the Nautilus.”  
+Airdate: April 02, 2017
+
+- Killian is on a **Wondrous Journey** to a **World of Color** where **Magic Happens**.
+
+![Screenshot from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*quAqRchBMkktQhuDQYOKoQ.jpeg)
+*And everyone dresses like this, no big deal.*
+
+- Emma tells David. Now we see whether David can handle it. Of course, they don’t know Killian’s departure was not of his own choosing.
+- Faran Tahir and Oded Fehr in the same episode? Lucky us!
+- Kraken Blood works as portal fuel, that’s new.
+- “Surely you can’t be serious!”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*q9-CHpQccZjkOfBLJH0AQQ.gif)
+*It’s a ship that goes underwater, but that’s not important right now.*
+
+- So we’re wandering the Enchanted Forest in the winter just looking around for a desert. Smart?
+- **That’s** the greatest crown jewel? Not impressive.
+- We need a hero!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*YOxoR3innVR0sbT6p0GF4w.gif)
+*“Cover Up” will be right back.*
+
+- Jafar! Wish noise!
+- The *former* Prince Achmed, that is.
+- I think we found the Kraken.
+- Nice shot, Hook.
+- The files were created with “Dark Curse Technology” and financed through Silicon Valley Bank.
+- Regina looks great!
+- Aesop’s Tables.
+- The look Regina gave David. So good.
+- They couldn’t just harvest the Kraken right there outside the sub? No wonder Killian is extra grumpy.
+- Side quest! Track down the evil sorcerer and get him (in some unexplained way) to just zip you home. I’m sure Jafar will be all too pleased to help out.
+- Henry has wired earbuds. They used to be a thing.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*iB-WZgJ5nZG_MrZca_AJwQ.gif)
+*Rip. Mix. Burn.*
+
+- Just Vikings shooting pool, nothing to see here.
+- Regina and Snow appear to be a few drinks in already.
+- This heart-to-heart between Killian and Jasmine is nice but not believable.
+- I do like the flashback Agrabah scenes though. Good costumes.
+- Why is Ariel in Agrabah?? And she stole a fork. Needed to comb her hair.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*0_EkROvZlclFd4Lakt-hSg.gif)
+*Look at this stuff!*
+
+- The necklace was a gift from Ursula if I remember correctly.
+- Ah, this is when Ariel was traveling the realms looking for Eric because mermaids have an inherent ability to open portals.
+- Eric never said he was traveling to Agrabah, though.
+- That was pretty convenient, right?
+- Aladdin could have zipped the Nautilus to the island, but instead, he just takes the crew.
+- Drunk Snow is hilarious.
+- Off-season Tiki bar. Sign me up.
+- Why does Jafar have so many corkscrews??
+- Jasmine! Ariel! Hook! Ariel! Janet! Brad! Doctor Scott!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*-LDv2aHSDtFMTMMVnv2yqQ.gif)
+*“Ugh!”*
+
+- (This explains the corkscrews)
+- “A Supposedly Fun Thing I’ll Never Do Again”
+- There’s a llama in the background of this scene. Is it Kuzco??
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*lietxiQKEhTrnjgwj0avPQ.gif)
+*OUaT not including Kuzco, Kronk, and Yzma is just a crime against storytelling.*
+
+- “I was bored with regular girls.” My jaw dropped until the Jafar reveal.
+- I feel like this is probably a bad plan. Didn’t we just say that wishes never work the way you want?
+- “Son of a fish!”
+- Wait Agrabah is a peaceful city we have no weapons you can’t possibly…
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*MijRsY5afMdU4GkZ2YpMRA.gif)
+*Constantinople. They’re in Constantinople.*
+
+- “Rather smaller than is ideal for trade agreements”
+- Snow 100, Vikings 46. And Snow is wearing one of their helms.
+- Aesop came from the Land of Untold Stories. Now he runs a bar. That’s a spinoff series I would watch.
+- Did we learn why Eric and Ariel live in a tiki hut?
+- Again with the hovel.
+- One TLK coming right up!
+- (Shining, shimmering, splendid)
+- Meanwhile, who gets to keep the screaming Jafar head?
+- “I’m an oyster-head”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*TXKHqdcN_IOmceOrFpMa1g.gif)
+*I hope this episode isn’t the last we see of Ariel.*
+
+- A shell phone, of course. I’m totally here for lovably goofy Ariel.
+- Uh. That wasn’t Aesop. Not cool.
+- I’m afraid the deflector shield will be quite operational when your friends arrive.
+- Gideon wants Emma to kill the Black Fairy, his grandmother. This guy!
+
+#### S6:E16 Mother’s Little Helper
+
+“Hook bets his most prized possession in a card game.”  
+Airdate: April 9, 2017
+
+- “Mother’s Little Helper” is a song by the Rolling Stones (about Valium) featuring Keith Richards, who played Captain Jack Sparrow’s father in one of the PotC movies. Disney connection: ✅
+- Jaime Murray as the Black Fairy. This season’s delightfully over-the-top scene-chewer.
+- “You have no power over me.”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*6CGPSpq2OagUeZGISTJMjg.gif)
+*And you don’t dress nearly as well as David Bowie.*
+
+- (Dearie)
+- Poor Roderick.
+- I like Emma’s outfit a lot.
+- All of the darkness comes from the Black Fairy. Including the Dark Ones?
+- Town line protection spell, check. Freed the Dragon from the mirror realm, check. Oh, he can go back to his family in San Francisco!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*dpnX8A-P7U4JSf91QZ6nSg.gif)
+*This makes Nicky and Althea Disney Princesses by association.*
+
+- And got Doctor Dolittle out of a cage, don’t ask. Henry’s look!
+- Uh oh, what’s got into Henry? This isn’t the Author's pen.
+- What kind of dust does the Black Fairy need? Seems bad.
+- Maybe hand over the sword in the sheath with the belt. Handing off the drawn sword is less helpful.
+- So wait, after all of Emma’s premonitions, Gideon just gives up? I said his mission was pointless but I didn’t expect him to realize it.
+- Hey, it’s Blackbeard! “Not since you lost the Jolly Roger in Arendelle.”
+- Is this where Han wins the Falcon from Lando in a Sabacc match?
+- I wonder if this is a trap. Gosh.
+- It’s a bug hunt.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*CH0QyERsAolYTiheaMIPYQ.gif)
+*How can the laboring man find time for self-culture?*
+
+- Who had a web-blob shooting spider on their bingo card?
+- Hmm, no ship. Do you remember where we parked?
+
+```
+-   [Magical whirring]
+-   Isaac! Nice to see Patrick Fischler.
+-   “Hamilton tickets.” Hey, Hamilton is on D+ which means it’s fair game. Angelica and Eliza are definitely Disney Princesses.
+```
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*b7hQqQsvYkBtB6VcF3VlNg.gif)
+*And Peggy, obviously!*
+
+- Rumple didn’t create the Dark Curse?
+- They really messed up the Grand Californian lobby.
+- Where did they end up? I kind of love this buddy comedy bit.
+- Oh no, back in Neverland. Again.
+- Hey, thanks Gold.
+- (Squish)
+- The Terrarium of Invisibility.
+- “This is on you, Gideon! And my boot.”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*Eu1TXgc4IH9iOJwsuqZzTg.gif)
+*The show is suffering a little bit from Big-Bad Escalation Syndrome, but I’m here for it.*
+
+- Hmm. Gideon was being controlled via heart the whole time. I guess.
+- Curse your sudden but inevitable betrayal.
+- “I’ll never look at Spider-Man the same way.”
+- Always with pointless promises, Gold.
+- Amazing dress on the Black Fairy!
+- It’s true, nobody’s magic was powerful enough for Hamilton tickets in 2017.
+- License plate: WED 1901
+
+![Screenshot from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*wfl480YayA4rPcxbdat3QQ.jpeg)
+*Too subtle?*
+
+- The Final Battle. What could that be? We have eight episodes left this season to find out!

--- a/src/content/ouatrevisit/2023-05-02-ouatrevisit-s6e1718.md
+++ b/src/content/ouatrevisit/2023-05-02-ouatrevisit-s6e1718.md
@@ -1,0 +1,151 @@
+---
+title: "#OUaTrevisit: S6:E17/18"
+date: 2023-05-02
+description: "The storylines are heating up as we approach the Final Battle!"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s6-e17-18-2621671e1a2c"
+---
+
+### #OUaTrevisit: S6:E17/18
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+The storylines are heating up as we approach the Final Battle! A flashback to pre-season one, a quick visit to Neverland and another to Oz, and some wedding planning. And more delightful scene-chewing by the Black Fairy, who doesn’t seem to have a name other than her title.
+
+#### S6:E17 Awake
+
+“Hook and Tiger Lily join forces against the Lost Boys.”  
+Airdate: April 16, 2017
+
+- Tiger Lily, not Maleficent Junior Lily. We haven’t seen Malefecient’s daughter Lily in quite some time.
+- Meanwhile, in Neverland, “Get the pirate! Make him pay!”
+- Regina’s severe black suit is 🔥
+- David grabbing Regina’s hands to make his point really shows how far they’ve all come.
+- Ohh, pre-season one flashback!
+- The sly smile on Mayor Regina’s face!
+- Wait what? David wasn’t cursed, he remembers it all? And now she remembers?? This didn’t happen.
+- Zelena is helping our heroes, I like it.
+- A failsafe. Pretty sneaky.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*MidnX8tyPHR3f_mzvEGtMA.gif)
+*Your opponent can sneak up on you and win the game.*
+
+- This whole scene absolutely did not happen in the established history. Fascinating!
+- “Reg- I mean Mayor Mills” (wince)
+- Pixie petals! They grow “in reaction to great evil” which sounds delightful. And the great evil is, of course, the Black Fairy.
+- Oops, BF has the dagger. Must have grabbed it from Gideon.
+- “I’ll never join you!”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*O1H4MXArKHaef4gqODJEFg.gif)
+*Wouldn’t you give your hand to a friend?*
+
+- Did Gold really not remember? I thought he did.
+- THAT’S what woke him up. Emma.
+- The flower of plot convenience.
+- Meanwhile, back in Neverland again… What’s up, Tiger Lily?
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*iLo3R8_Qo0JhhOXzCjwXqA.gif)
+*Her OUaT outfit is pretty accurate to the animated movie.*
+
+- “The coming war” is the final battle Isaac was talking about, yes?
+- Regina suspects MM is awake, but she’s not sure.
+- It’s a super-bloom!
+- You’ll know when the final battle begins, because it’ll be in the episode slug. “The Final Battle Begins.”
+- The most powerful wand ever made, so, the Sorcerer’s wand? Or is this one even more powerful?
+- Tiger Lily used to be a fairy, okay, sure.
+- Oh no, not Pumbaa!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*g7_gnWTyZBvnqxq_TAaoPg.gif)
+*Gas-fired grill?*
+
+- “Get her? That was your plan?”
+- It’s Hook’s shadow.
+- He does, actually, have a child who is out there.
+- One flower left! Hey laughing boy, one flower left!
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*T_rrHVR1sZ_nCBMfMtk82g.gif)
+*I know, I know, one flower left.*
+
+```
+-   [Magical Tinkering]
+-   What cassette is Emma listening to on her Walkman? I can’t make it out.
+```
+
+![Screenshot from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*O2rP7Sq1rIEhzaHfd_GmYQ.jpeg)
+*Does this cassette cover ring any bells?*
+
+- Bottom of the pile: a bootleg copy of Wang Chung.
+- Rumple said they’re eighteen years too early for Emma’s 28th birthday. Season one takes place in 2011, which means this scene, looking in on Emma at age ten, is in 1993. In 1993 I was 23, just back from Desert Storm, and playing a lot of D&D.
+- Does Regina react to Snow admitting she’d been awake after all? I would have liked Regina to say “I knew it!” followed by dirty looks and then under her breath “(I knew it.)”
+- The powder worked! But they left Tiger Lily behind. I suppose she’ll be okay.
+- I thought for a minute that TLK might break the current curse, but no.
+- Risky, you say? We’re in!
+- If everyone takes a sip then the spell’s power is diluted. Okay.
+- (I’m pretty sure the goblet is empty)
+- Oh everyone is asleep. Creepy.
+- Good on you, David.
+- If you come at the Black Fairy, you’d best not miss.
+
+#### S6:E18 Where Bluebirds Fly
+
+“Zelena decides to take on the Black Fairy.”  
+Airdate: April 23, 2017
+
+- I don’t see this ending well for Zelena. She’s more powerful than Regina, but not Darkest Rumple and definitely not the Black Fairy.
+- Does the Black Fairy even have a name?
+- We’re back in Oz with Young Zelena!
+- Young Zelena who has not yet learned to maybe not show off her power so openly.
+- “Are you a witch?”
+- Ugh, monster again.
+- “Stanum” feels like it was a placeholder name in the script that wasn’t removed for shooting.
+- Ohh boy. BF starts off by taking Baby Robin.
+- Zelena doesn’t deny she’s wicked.
+- “I’m not afraid.” “You will be.”
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*5oWCMkrWV3eZPbX87-pSaQ.gif)
+*In this creaky metaphor, Zelena is Luke and Baby Yoda is Yoda.*
+
+- “A quick and bracing shower.”
+- When did Emma get an iPhone? This is 2017, but most Storybrookians still have flip phones.
+- Zelena’s reaction to BF’s half-threat was to call Regina, who called Emma. Zelena may not be a hero (yet) but she’s leaving villainy behind.
+- “Noir-colored nit!”
+- The Blue Fairy is older than Rumple. We didn’t know that.
+- Belle and Zelena don’t have much in common but I like how they bond over motherhood.
+
+```
+-   [Magical Tinkering]
+-   Neat glowing pen. Can I buy one at World of Disney?
+-   David recognizes something in Henry’s drawings. He’s not going to go off and do something dangerously stupid without telling anyone, is he?
+-   “Your Wickedness!”
+-   I like how Zelena’s guards are definitely inspired by the movie.
+-   Dumb Zelena/Regina fight. Just dumb.
+-   Let’s get married at Granny’s! Sure, I guess?
+-   What’s gotten into David though? He’s being jerkier than usual even for him.
+-   I don’t care for the way Regina talks down to Zelena.
+-   Good thing her green makeup isn’t running in the rain.
+-   Hey, it’s Aslan. Disney made two Narnia movies, so they’re fair game.
+```
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*oOvzij5F-PsPOTlHPI2qZg.gif)
+*He is a very large lion.*
+
+- Fairy crystals. Is that what makes fairy dust?
+- “I’m not interested in Light Magic!”
+- They’re running through the pirates tunnel on Tom Sawyer Island, right?
+- Oops, now all the crystals have been turned dark. That seems bad.
+- Bad CGI on the lion. Like, really bad.
+- Jeez, Regina, this is not cool. I don’t like it. Don’t treat your sister like that.
+- I don’t care about David shvitzing about the wedding. Has he made one objectively correct choice in the entire series?
+- Does Zelena have a bean or something else to open an Oz portal? Oh, she’s using a crystal fragment.
+- So the magical glass heart is just… laying there?
+- Wicked Zelena. Whatever. Leaving Stanum there to rust.
+- Now it’s time for you to apologize to Zelena, Regina.
+- This is pretty clever: Zelena’s magic powers the black crystals, so if it’s drained into the glass heart, the crystals are empty. Maybe.
+- The Black Fairy is back to square one, but the heroes are down by their most powerful magic-user.
+- A little crumbled Pixie Crystal is enough to kick-start Blue’s heart.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*vdxiKC1KDV1b5RbQiN8IMg.gif)
+*Say I got trouble, trouble in my eyes  
+I’m just looking for another good time*
+
+- Oh, what could BF’s Darkest Secret possibly be? Drama!

--- a/src/content/ouatrevisit/2023-05-11-ouatrevisit-s6e1920.md
+++ b/src/content/ouatrevisit/2023-05-11-ouatrevisit-s6e1920.md
@@ -1,0 +1,110 @@
+---
+title: "#OUaTrevisit: S6:E19/20"
+date: 2023-05-11
+description: "OH MY WHAT THERE’S A MUSICAL EPISODE"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s6-e19-20-2bd7d48068b8"
+---
+
+### #OUaTrevisit: S6:E19/20
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+OH MY WHAT THERE’S A MUSICAL EPISODE
+
+Sorry. First things first: #OUaTrevisit supports the WGA.
+
+![Screenshot from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*J4DCnuBa6l-ErL2AsWEghg.png)
+*From OUaT writer Adam Horowitz’s [Instagram](https://www.instagram.com/p/Cr_mAM7PX2K/?utm_source=ig_web_copy_link&igshid=MzRlODBiNWFlZA==)*
+
+I find myself wishing I’d experienced this amazing spectacle in real time with everyone else. S6:E20 aired only six years ago, so most of the reactions and blogs and such are still online. Did I spend a few hours after watching digging deep into “WHAT DID THEY JUST DO?!?!”, yes, yes I did. But first, episode 19.
+
+#### S6:E19 The Black Fairy
+
+“Rumple’s mother learns his destiny is prophesized.”  
+Airdate: April 30, 2017
+
+- Fairies!
+- Finally, we have BF’s name: Fiona.
+- Tiger Lily is Rumple’s fairy godmother. Huh. Did she just draw the short straw or what?
+- That’s a much better dress for Blue!
+- Oops, the unhatched dragon egg fumes didn’t wake up the icon of good. Or did it? Does she wake up as herself? It would be like “I’m sure this toxic substance will help, let’s try more.”
+- Did not care for the strangulation scene, even after BF transformed.
+- Zelena has no magic so she has to assemble IKEA furniture by hand.
+- Ugh, Belle, really? He lies and betrays you over and over and all you do is cling to him.
+- Emma gets a cute slouchy knit cap in the dream realm.
+- “Saviors have the luxury of always doing the right thing.”
+- Who has a scar like a crescent moon? Somebody we haven’t seen yet.
+- A little bit of Welsh and Fiona transforms herself into a fairy. How well did that work out for Jafar, though?
+- Zelena’s driving lesson! Is it a Gremlin or a Pacer?
+- Ooh, the Sacred Fairy Vault. Is it next door to the Indiana Jones vault?
+- (Dearie)
+- Secrets under the jukebox. There were other things in the cache, too.
+- I don’t know, Regina at full power has a pretty good win/loss record.
+- Zelena took to driving pretty quickly after all.
+- After all this buildup, what could the big secret possibly be?
+- Fairy Fiona becomes the Black Fairy through her act of evil. And she has the scar, which means she’s destined to destroy her son.
+- Rumple is a Dark Savior! This means Belle is going to once again fall for him, sigh.
+- Oof. Fiona used the Shears of Destiny on baby Rumple. And was promptly banished to the Phantom Zone.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*TRWQNtYos4mZx0PC4jxTRA.gif)
+
+- This whole family belongs on an episode of some 90s daytime talk show.
+- Wow, Dad, way to cast all your troubles onto your infant son. I suppose this is why you didn’t feel too sorry about, you know, abandoning him on a jungle island.
+- Seems like we missed part of the story there. What did Rumple really do to Fiona? I don’t believe anything he says.
+- Yeah, he’s lying.
+- Aw, “Operation Best Man.”
+- Do not block the gate ever!!!
+- Whose heart was that then, or was it even a heart?
+- Yeah, lady, Emma gets wacko threats like yours every day and twice on Sunday. Have you never even seen the show?
+
+#### S6:E20 The Song in Your Heart
+
+“Storybrooke residents discover the power of song.”  
+Airdate: May 7, 2017
+
+- Young Emma is trying out for the talent show by humming the show theme.
+- Did Snow just wish upon a star? I hear that helps.
+- This…this is the best thing I’ve ever seen.
+
+*“With our powerful magic, we now have the means, ’cause love can defeat curses, potions, or beans.”*
+
+- Regina, Zelena, and Emma having mimosas.
+- Emma’s makeup this week doesn’t look good. Are we trying to portray stress or was it just inconsistent?
+- EQ and Mirror Sidney singing a duet. I am here for this.
+
+- She just killed those guards! Why would you even sign up with her?
+- Just staring open-mouthed at EQ’s power ballad.
+- “Let me help.”
+- Smee!
+- Hook’s song! This just keeps getting more amazing.
+
+- BF has the drop on Hook. Now she has a hostage. Except he escapes, or she lets him go?
+- Why does Emma still have the tape recorder and why is it still cued to that point?
+- I was looking forward to Robert Carlyle singing.
+- Zelena wasn’t really in this part of the story but OMG this song.
+
+*“What they call green with envy, I just call looking good.”*
+
+- This song wins, for me. The best out of all of them. If you watch ’til the end of the embedded video above, there’s a clip of Rebecca Mader singing live at a convention; I recommend it.
+- Regina needs to upgrade her security spells. Too easy to get into the vault.
+- Emma has always had this self-sacrifice thing.
+- The look of disgust on EQ’s face when Snow and Charming start singing!
+
+- The voice-taking spell is Zelena’s but it resembles one Ursula used once or twice.
+- Her heart can’t be crushed because it has her family’s songs in it. Or something.
+- And now, a musical recap of the previous six seasons, set to the tune of the show’s theme.
+
+*I wish we’d had a Fiona song, actually.*
+
+- Archie is going to marry them!
+- Emma’s dress is perfect.
+- “For all eternity” is maybe a little on the nose.
+- The songs sound an awful lot like “Enchanted” and “Tangled”. That’s a good thing.
+
+- And now the news, with Leroy.
+
+![Reaction GIF from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*ZcqG_6gsjpkkhug9xFsQMw.gif)
+*How else would we know something terrible is about to happen?*
+
+- Btw: you can buy [the songs from this episode](https://music.apple.com/us/album/once-upon-a-time-the-musical-episode/1429666323). $7.99 on iTunes.

--- a/src/content/ouatrevisit/2023-05-16-ouatrevisit-s6e2122.md
+++ b/src/content/ouatrevisit/2023-05-16-ouatrevisit-s6e2122.md
@@ -1,0 +1,111 @@
+---
+title: "#OUaTrevisit: S6:E21/22"
+date: 2023-05-16
+description: "Not the #OnceUponATime series finale but a startlingly good imitation of one."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s6-e21-22-50e6b649a3c8"
+---
+
+### #OUaTrevisit: S6:E21/22
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+I don’t know for certain that this two-parter was written and filmed to be the series finale, with the framing scenes featuring adult Henry and daughter Lucy added in later after the series was picked up for a seventh season. But my TV-writing-analysis brain is screaming that this is what happened. The last five minutes of “The Final Battle, Part 2” were as much an ending, a wrap-up, an “everyone gets a final coda,” as any series finale I’ve ever seen.
+
+But before we can talk more about Part 2, we need to get through Part 1.
+
+#### S6:E21 The Final Battle Part 1
+
+“Henry awakens to a cursed Storybrooke.”  
+Airdate: May 14, 2017
+
+- I told you it would be obvious when the Final Battle was getting underway.
+- How many curses does this make for poor put-upon Storybrooke now? Five or six?
+- This “previously on” is going Way Back.
+- They definitely won’t find me if I run with a torch, thinks the guy running with a torch!
+- This time, Henry is the only one who remembers.
+- Emma painting a swan. Just one swan. We’ll call her Emma Solo.
+- Kinda feel like the townspeople would be better off in this situation, right? No periodic curses, evil creatures, or sorcerors breezing in to destroy the town every so often.
+- Maybe Henry should avoid all this talk in front of the mental institution nurse.
+- Oh, Fiona is now the mayor and Henry’s other mom.
+- The curse requires drugs to keep the memories down? Definitely weaker than Regina’s ever were.
+- And the rest are back in the Forest, but they do remember.
+- Institution Emma is giving strong Linda Hamilton in Terminator 2. Next, she’ll knock out some pull-ups.
+- “He was a Hatter, he had multiples.” Zelena with the killer line.
+- Hook seems grumpier than usual. Like, we know, we all want to get home. Calm down.
+- What are the various Realm Doors? The wallpaper is very Haunted Mansion. Regina mentioned Arendelle. One of them looks vaguely space-capsule and another is definitely Polynesian. If there was a door that would transport directly me to the [Trader Sam’s Enchanted Tiki Bar](https://disneyland.disney.go.com/dining/disneyland-hotel/trader-sams/), I’d be a regular.
+
+![Screenshot from Once Upon a Time Season 6 recap](https://cdn-images-1.medium.com/max/800/1*VffOl2qiDKoESULz8jreHQ.jpeg)
+*Could we have a door that leads to Pleasure Island before it was destroyed? #Kungaloosh*
+
+- Oh hey, Aladdin and Jasmine. Nice to see you. What happened to your leg, Aladdin?
+- Naturally, Mayor Fiona is driving the Mayoral Mercedes.
+- “Gold and Son” is a nice touch.
+- Something happened to Belle but we aren’t saying what.
+- So we’re evacuating everyone in all the realms into this little anteroom?
+- Ha! Pull-ups! I knew it!
+- This is quite a hero speech from Killian.
+- Henry also conveniently recovered all of Emma’s regular clothes.
+- What does Henry have in mind? It’s not going to be “help Emma leave town.”
+- Matching suits on Gold and Son.
+- We’re out of Lizard Horn! Just run down to the [Exotic Spice & Tea Shop](https://grimm.fandom.com/wiki/Exotic_Spice_%26_Tea_Shop) and pick some up.
+- Who is making a grand entrance now? Oh, it’s the less-evil Evil Queen.
+- “I don’t murder anymore, Zelena.”
+- Fiona is just having a day, isn’t she? It’s like she’s a DM and the players aren’t following her carefully-planned dungeon map, just rolling for initiative willy-nilly.
+- Hey, is Tiny here?
+- David called Killian his son-in-law. And we’re getting some Captain Hook music.
+- You can’t fool me, that’s a coconut Jelly Belly.
+- Dragon! Is it Lily? Whatever happened to Lily?
+- “You mean?!” “Yes, she’s become an Instagram influencer.”
+- Emma bursts into the hospital like she isn’t an escaped fugitive.
+- The extras in the Realms anteroom look concerned.
+- Emma really DeSantised that book.
+
+#### S6:E22 The Final Battle Part 2
+
+“The Heroes are trapped in a crumbling Fairy Tale Land.”  
+Airdate: May 14, 2017
+
+- Why is the Seattle Center Monorail in the opening?
+- Who is the little girl? And how does she know Tiger Lily?
+- Fiona really has it out for Henry, who is by the way her great-grandson.
+- Go carpet!
+- “Hello there, mummy.”
+- The Three Bears Day Spa. I bet there was more in the small print.
+- Revivifying the bean will require a full Queen’s worth of magic. Will they re-join?
+- Hey, surprise, the TLK worked.
+- Gold is awake, of course. I think Extra Dark Gold’s magic might even beat the Black Fairy’s.
+- I expect Belle is probably locked up in the hospital basement.
+- Emperor-level Force lightning!
+- “My name is Henry Mills. You killed my family. Prepare to die.”
+- Emma came back! And just in time, it appears.
+- The house next door to Belle has a satellite dish. But in Storybrooke they only get ABC and ESPN.
+- Gold’s shop has everything, if you look hard enough.
+- She’s been looking for the wand for centuries? Fiona had her wand in the Fairy realm. How long have we been in this current curse?
+- What exactly are the Laws of Magic? Have we heard of those before? More like guidelines, I suppose.
+- I feel like this is the wrong tack to take with Gold.
+- (Dearie)
+- “Only light can snuff out the light,” that doesn’t make any sense.
+- “I don’t feel so good.”
+- Poof! Now RumpleGold has killed both of his parents.
+- And we’re back!
+- Ah jeez, this guy again. Gideon switches from “boring but good” to “boring but menacing” at the drop of a boring cloak.
+- “Belle, you’re standing in…”
+- Henry with the fire extinguisher!
+- Oh whatever, Belle.
+- The babies (Neal and Robin) are only around when they need to be for plot purposes. Where are they now?
+- This isn’t what Emma was wearing in her vision. Ever in motion is the future.
+- I love the complete understanding between Regina and Emma, finally.
+- Walkie-talkie mode doesn’t work. Storybrooke LTE (2017) doesn’t reach that far underground.
+- Gideon was always going to kill Emma, but what is spewing from the wound? Light Magic? Butterflies? Sparks off her impenetrable plot armor?
+- TLK is like a natural 20 on the saving throw.
+- Is this baby Gideon?
+- It’s an OUaT Greatest Hits montage!
+- The Charmings have a dog!
+- Regina Mills, Queen (bow).
+- I bet this was supposed to be the series finale. You couldn’t ask for a more complete wrap-up (except what about Ruby/Dorothy, and Lily, and August, and and and).
+- That final dinner scene! ❤️
+- “Seattle, years later.” Is this Henry’s daughter? Was that adult Henry in the scene with the sword?
+- Are we just starting over from the beginning??
+
+Apparently, most of the regular cast departed after season six; further bolstering my suspicion that this was going to be the series finale. I guess we’ll see how adult Henry’s daughter bears the burden of being the one to bring her parent(s) back to Storybrooke. Starting next week: season seven! The final season! 22 episodes, eleven weeks, which means #OUaTrevisit will wrap up on or around August 2nd.

--- a/src/content/ouatrevisit/2023-05-24-ouatrevisit-s7e12.md
+++ b/src/content/ouatrevisit/2023-05-24-ouatrevisit-s7e12.md
@@ -1,0 +1,98 @@
+---
+title: "#OUaTrevisit: S7:E1/2"
+date: 2023-05-24
+description: "AfterOUaT."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s7-e1-2-e9d1dbfc2ac8"
+---
+
+### #OUaTrevisit: S7:E1/2
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+Instead of ending on a triumphant note with the season six finale, we’re heading into the “AfterMASH” era of OUaT where we’re in a different setting, with mostly different characters (but a few cameos from the old days) and having to explain literally everything.
+
+Based on the first two episodes, I’m not sorry we’re in the final season.
+
+#### S7:E1 Hyperion Heights
+
+“Henry Mills leaves Storybrooke on a new journey.”  
+Airdate: October 6, 2017
+
+- Storybrooke-Henry (Jared S. Gilmore) is just completely grown now.
+- And has August’s motorcycle and a portal bean.
+- The portal looked like a Doctor Strange spell! #synergy
+- “A new realm, years later…” and a new actor playing Adult Henry. But poor motorcycling skills.
+- In the opening: Seattle, where Adult Henry is driving for “Swyft”.
+- (This is the scene from the end of S6:E22.)
+- Her mom is Cinderella! But a different one than we know.
+- Cindy’s stepmom is Lady Tremaine, yes?
+- Jacinda works for a jerk.
+- The troll under the bridge does exist, I’ve been there.
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*7OWJS4ec0gTHOqY4nXXH5g.jpeg)
+*Me at the Seattle Troll, June 8, 2019.*
+
+- Uh, Roni is Regina? With a fantastic hairdo.
+- Cindy’s dress is going to burn up on the exhaust pipes.
+- 👊🏽🤷‍♂️🏍️
+- Jacinda’s roommate is played by Mekia Cox, of The Rookie.
+- And Victoria Belfrey is played by the amazing Gabrielle Anwar (“Burn Notice”).
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*8fEm1raHzTaJd2i6AEuCGw.gif)
+*“Where am I?” “Seattle.”*
+
+- If Fiona NoLastName could use a stolen wand to turn herself into the Black Fairy, I guess Lady Tremaine can use one to straight-up murder a fairy godmother. Seems like you’d want biometric authentication on those things.
+- Looks like the old Storybrooke wishing well.
+- That’s a pretty great line, Henry.
+- “Oh, frog legs, no thank you.” Could this be Tiana?
+- Revenge is a dish best-served cold. Like frog legs.
+- That was the girl from the rooftop earlier, and it’s Alice. Interesting.
+- “Weaver” as in Rumplestiltskin, who famously spins straw into gold.
+- Relationships: Jacinda is Lucy’s mother. Victoria is Jacinda’s stepmother.
+- How does Victoria know Henry? Presumably, because she cast the curse, and is therefore in the Regina role of being the only one “awake” in the resulting timeline.
+- Officer Killian!
+- Alice from Wonderland, and other places!
+- It’s hard to see Henry in the role of the one not believing. But it’s also kind of obvious.
+- Bainbridge Island is not a bad choice, as long as you have a boat.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*BcUWQIs8r4JuK1cU5dTDOQ.gif)
+
+- “Officer Rogers” as in Jolly.
+- That is absolutely a Doctor Strange portal. I bet the OUaT crew borrowed it from the MCU production team (Doctor Strange: 2016).
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*NngCh0FR1IoFssjXf9-4Eg.gif)
+*Raising many more questions about the source of OUaT magic.*
+
+- Go, Roni! Maybe a bit too much monologuing though. Reminds me of another overlong Regina voiceover monologue from an earlier season.
+- Emma!
+- Are you going to start your second book just like your first? I guess that’s a choice.
+- “Regret’s not really my thing.”
+
+#### S7:E2 A Pirate’s Life
+
+“Henry calls upon his Storybrooke family for help.”  
+Airdate: October 13, 2017
+
+- Hey, it’s a flashback, with teen Henry, Killian, and Emma.
+- Adult Henry was easily captured. The little bottle seemed kind of a silly way out.
+- Not a great dress on Lady Tremaine.
+- “You seem a lot nicer than she is.” “I’m not.”
+- Why didn’t Emma show up though?
+- Robert Carlyle has a different accent.
+- “WorkBunny” which is definitely not TaskRabbit.
+- “I’ve gotta hop,” says Jacinda’s friend who I think is Tiana.
+- Drunken fool version of Killian. Multiverse!
+- Creepy plan by fake Killian.
+- I’m kinda into the detective team-up.
+- “Granny’s added poke.”
+- What is going on with Emma??
+- A little bit of Captain Hook music.
+- I figured fake Killian wasn’t going to be into being a dad, but it turns out he’s a good guy.
+- Detective Weaver is totally corrupt. Surprise.
+- Family lines getting awfully complex around the Killian Jones family. Multiverse Hook has a daughter!
+- Emma has healed people worse off than fake Killian. No reason to doubt herself.
+- I don’t really get the Weaver/Victoria dynamic yet.
+- I see, Regina stays here with Henry and Other Hook, and they are eventually cursed to live in Seattle. At least we seem to be filming in the actual location.
+- This episode is mostly people explaining things to each other.
+- So it’s “Operation Take Down Victoria”.

--- a/src/content/ouatrevisit/2023-05-31-ouatrevisit-s7e34.md
+++ b/src/content/ouatrevisit/2023-05-31-ouatrevisit-s7e34.md
@@ -1,0 +1,99 @@
+---
+title: "#OUaTrevisit: S7:E3/4"
+date: 2023-05-31
+description: "I’m mostly just bored. That’s not what I want from my entertainment, and I’m not surprised this was the last season."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s7-e3-4-a44abaaacddb"
+---
+
+### #OUaTrevisit: S7:E3/4
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+Bored. I’m mostly just bored. That’s not what I want from my entertainment, and if my response is anything like the general view at the time (2017–18 season) then I’m not at all surprised that this was the final season.
+
+That said, if we could have had a spinoff season about Rumple’s quest to rid himself of the Dark Dagger of Supreme Darkness, I’d have watched it.
+
+#### S7:E3 The Garden of Forking Paths
+
+“Cinderella receives help from an unlikely source.”  
+Airdate: October 20, 2017
+
+- Forking paths!
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*fXep4cuWwTVuBog7gvQgFQ.gif)
+
+- There’s no way Cinderella’s dress wasn’t caught up in the motorcycle chain or burned on the exhaust.
+- Aha, it is Tiana! 🐸
+- “Our one-handed detective”
+- Convenient drunk customer. Maybe too convenient.
+- Always bring donuts, basically.
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*Lny2yz-cr6uDCyd3_PNFng.jpeg)
+*Hopefully Top Pot. They are in Seattle. Remember?*
+
+- Tiana is the leader of the resistance. Okay?
+- “Come with me to the resistance camp in the woods while wearing our fancy ball gowns.”
+- Detective Weaver caught a glimpse of the Building Commissioner’s stat sheet. And a pretty obvious public payoff.
+- “I’m a regular queen,” says the person from a better show.
+- Hey look, a dangerous hole in an open construction site. Let’s jump in!
+- Already tired of Lucy trying to explain the curse. Again.
+- What is up with Cindy though?
+- This conversation between Lady Tremaine and Cinderella is confusing. Lots of “but then…” “and he…” “and I…” super frustrating!
+- And dumb. Tremaine needs Original Henry’s heart to… resurrect her other daughter?
+- Okay, let’s burn the petition without any contract or agreement beyond Victoria’s easily ignored promise. 🙄
+- Cindy, here, is about to pull a David and do the Wrong Thing. In the grand tradition of OUaT heroes.
+- Yay, Regina.
+- We’re going to keep this garden for the community! With a dangerous hole in the middle!
+- Fantasy Realm Regina’s outfit in this episode is amazing.
+- A few names on a petition will not stop a project that’s already started.
+- I’m not clear on why or how Henry found the cemetery that didn’t exist until now.
+- Who does Victoria have captive? Our Lady of Perpetual Exposition.
+
+#### S7:E4 Beauty
+
+“Weaver’s exchange with Tilly goes awry.”  
+Airdate: October 27, 2017
+
+- Speaking of Tilly, I hope she’s back on Discovery when it returns.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*ezOn5OISkPs1PbUKtCIgJw.gif)
+*Captain Killy is the best Tilly.*
+
+- Baby Gideon!
+- “I can’t even remember the last time I used the dagger,” says oh by the way still the Darkest Dark One.
+- That was it, that was the promised Exchange with Tilly.
+- “You’re lucky she didn’t exile you to Canada.” (Ha ha they’re in Canada)
+- “Who R U?” 🍄
+- Gabrielle Anwar’s posh British is a little bit unconvincing this week.
+- “I’m altering the bargain etc etc”
+- The Poisoned Apple 🍸
+- The outfits and decorations in Roni’s bar!
+- The impressive concrete suspension bridge is the Port Mann Bridge in Surrey, BC.
+- Weaver and Rogers are walking funny?
+- Belle looks great with the gray stripe!
+- Are we just gonna throw the Supremely Evil Dagger of Darkness into a random river and just hope for the best?
+- Drusilla was not invited to the ball. Sad trombone.
+- Good thing we had already cast teen Gideon.
+- If this season was all about Rumple redeeming himself and casting off the mantle of the Dark One, I’d be a lot more into it.
+- Incredibles family!
+- Sheesh, Ivy is awful!
+- Classy, Weaver, drugging the girl’s sandwich.
+- I think this is Narnia actually.
+- Chip!
+- I’m told this whole scene with the house is basically the first part of “Up”. I don’t know because I have de-memoried that entire movie.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*EuRaxq30J1BUSOc6aDOXBA.gif)
+*There was a talking dog later on, right?*
+
+- Snow White costume 🤣
+- Did Weaver just have a memory from the before-time?
+- She came back to him, more than a few times. (YES WE KNOW)
+- And, then she shot him. Okay.
+- Another Doctor Strange portal. And who is this Guardian? Is it Alice/Tilly?
+- “Quiet as a Dormouse.”
+- Dearie!
+- Umm, that look from Ivy to CurseHenry is not keeping things uncomplicated. 🥃
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*7lboPUWaYPFdmeMWArqkjw.jpeg)
+*If you told me these two would have a thing coming up this season, I would not be surprised.*

--- a/src/content/ouatrevisit/2023-06-06-ouatrevisit-s7e56.md
+++ b/src/content/ouatrevisit/2023-06-06-ouatrevisit-s7e56.md
@@ -1,0 +1,108 @@
+---
+title: "#OUaTrevisit: S7:E5/6"
+date: 2023-06-06
+description: "Will Lucy succeed in getting Henry to believe and wake up? What happens if she does?"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s7-e5-6-b0416ac4fda8"
+---
+
+### #OUaTrevisit: S7:E5/6
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+I was a bit more engaged with this week’s episodes than last week’s, but I’m mostly just interested in how these stories are going to wrap up. Will Lucy succeed in getting Henry to believe and wake up? What happens if she does? Will Ivy/Drizella get her comeuppance or will she earn herself a Regina-esque happy ending?
+
+#### S7:E5 Greenbacks
+
+“Tiana seeks help from soothsayer Dr. Facilier.”  
+Airdate: November 3, 2017
+
+- Spotted in credits: Robin Givens. I bet she plays Tiana’s mom.
+- “My tea, my special brew.” Is the imprisoned expositorian the Queen of Hearts?
+- Today’s lesson: lock in the lease. None of this month-to-month nonsense.
+- Not super into this version of the Tiana story really.
+- Eyeroll at the helpless princess trope.
+- Roni wearing the CBGB shirt!!
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*6pr-_fgfbzRy8bTVEQ6DqQ.gif)
+*RIP*
+
+- I have a great idea of how we can make money and escape Victoria forever! Have you ever heard of Onlyfans?
+- Pleasure Island, salt mine, jackasses, I see what they’re doing.
+- Running the side baking business out of the chicken joint is going to come back to bite them.
+- Okay, Facilier’s outfit is great.
+- Magic always comes with a price.
+- Victoria is not a nice mom.
+- Hopefully, Victoria isn’t tapping Ivy’s phone.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*KC_O-cTt-PNCr0DZl1cIIQ.gif)
+*You got a burn notice, Henry, you’re blacklisted.*
+
+- Who leaves their phone behind when they leave the bar?
+- Coming soon to New Orleans Square: Tiana’s beignets.
+- Good line from Marius there about the legs half off. I feel like it’s a ruse though.
+- Wreck-it Ralph??
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*BO83KFV-HQOOH0nn7bcGdg.gif)
+*Ralph should have been played by John C. Reilly.*
+
+- A commercial kitchen will have automatic fire extinguishers. And tons of portables. Implausible that it would take out the whole building.
+- Marius just stole the medal, obviously. What a cad.
+- “I’m a man and my true love is…” a hawk?
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*Vwdd4vCnkzvIaVbuuesojQ.gif)
+*This only works if Rutger Hauer’s true form is a frog.*
+
+- Roni successfully manipulates Ivy into giving away Victoria’s secret. (It was made up by a dude)
+- Huh, I wonder what’s in that photo.
+- This ruby is going to set him free. Speaking of which, I miss Ruby.
+- I’m not sure you can effectively convert a box truck into a food truck. Better to buy one surplus or from the impound lot.
+- “Huh.”
+- Ugh, just awful, Victoria.
+- Baby Henry with the Tron lunchbox.
+- (Clever girl)
+- Ooh, she knows! IvyDrizella knows exactly what’s going on.
+
+#### S7:E6 Wake-Up Call
+
+“Roni seeks Weaver’s help in finding answers.”  
+Airdate: November 10, 2017
+
+- That’s two “seeks help” in two episodes.
+- The opening has Rapunzel’s tower in Seattle. Clever.
+- It’s clobbering time!
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*bm5eazcNm0xt9JZFbbHiHA.gif)
+*Back in 2017, Disney hadn’t secured the Fantastic Four rights yet.*
+
+- “If I were the Evil Queen…”
+- Forest Realm Regina’s outfit: 🔥
+- “You’re pretty good in a fight, we could use you.”
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*cCwWWZLT8NGhYOeOQCzrUg.gif)
+*Don’t everybody thank me at once.*
+
+- #Drunkoween
+- Ivy is NOT on your side.
+- Bella Notte pizza in the alley with stray dogs. Basically, they’re in the final season and dropping in as many last Disney references as possible.
+- Today Roni is wearing a killer Rick James tee.
+- “Be charming and don’t slouch.”
+- Feed me, Seymour!
+- “I know what it’s like to live with a controlling mother” Oh yes she does, but this is just a dumb Drizella plan to get something from Regina.
+- Could the Mysterious Captive be Mother Gothel? If not, then who?
+- “Say Anything” meme FTW. “A little New Order, a little Adam Ant.”
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*nKArMxgUERrNFAZmqROHbg.gif)
+*Henry has always had good taste in music.*
+
+- It’s a John Hughes cute scene and I like it.
+- Lucy was just expecting to find the book in her closet because it happened that way once before.
+- “I can’t believe it!” “That is why you fail.” Unfortunately, Drizella is no Luke.
+- WeaverRumple is definitely awake. His micro-expression changed when Roni asked about Regina Mills.
+- “Things are always more fun when you start in the middle.”
+- Rumple makes a very good point about Tremaine. She’s letting Drizella learn magic to make her heart more suitable for replacement.
+- Gregor was the man Drizella was supposed to marry, right? I’d forgotten.
+- Ohh is Drizella going to cast the Dark Curse? Pretty clever misdirection making us think it was Tremaine.
+- What did IvyDrizella put in Roni’s drink?
+- And now Regina is awake. And Drizella put a failsafe into the curse. “Something terrible” happens if it’s broken.
+- Lana is so good in these two scenes.

--- a/src/content/ouatrevisit/2023-06-15-ouatrevisit-s7e78.md
+++ b/src/content/ouatrevisit/2023-06-15-ouatrevisit-s7e78.md
@@ -1,0 +1,103 @@
+---
+title: "#OUaTrevisit: S7:E7/8"
+date: 2023-06-15
+description: "This week: We find Eloise. We find Alice. We find Jack. We’re doing the very slow plot reveal. We’re getting drawn in despite ourselves."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s7-e7-8-9e61a3cbe98e"
+---
+
+### #OUaTrevisit: S7:E7/8
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+I’m late, I’m late! Just in time to (re)-enter Wonderland, I’m channeling the always-delayed White Rabbit by posting my #OUaTrevisit piece a day late.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*R_3BkkL-xIFm3PFtRCiqhQ.gif)
+
+This week: We find Eloise. We find Alice. We find Jack. We’re doing the very slow plot reveal. We’re getting drawn in despite ourselves.
+
+#### S7:E7 Eloise Gardener
+
+“Hook seeks a dark and powerful magic.”  
+Airdate: November 17, 2017
+
+- (That’s altHook, remember, not primeHook.)
+- Smee!
+- Ah we’re seeing how EQ failed to cast her curse in Wish Realm.
+- Lana’s outfit in this scene ❤️🔥
+- “The tower is guarded by an evil witch”… Could that witch be who Victoria has in her Belfrey?
+- I don’t really care about the argument between altHook and WeaverRumple.
+- The food truck, that isn’t a food truck.
+- “I was thinking” (dangerous pastime) (I know)
+- Ivy’s threat is ominous but nonspecific.
+- The closed captioning just named Victoria’s captive “Eloise”. Which was unexpected.
+- altHook is looking for a “girl”. The timeline doesn’t match up.
+- “Today is indeed a good day!”
+- I think this is the same tower where later Regina was training Drizella.
+- Ah, of course it’s Rapunzel. With her frying pan.
+- TillyAlice has a Mickey Mouse watch.
+- Dirt on the shoes. Dead giveaway.
+- Eyeroll at Victoria’s sniffy threats.
+- Wrong song?
+- “You don’t have children, that you know of.”
+- Does Victoria think she cast the curse?
+- Ugh, I don’t like what Roni is doing here. IvyDrizella’s threat must be really bad.
+- Get on with it!
+- “Abandoning people just isn’t my thing.”
+- Ah. Hmm. Perhaps this isn’t Rapunzel after all, but the imprisoned witch?
+- The Evil Dark Dagger of Evil Darkness is in the evidence locker.
+- He doesn’t have a warrant for the code.
+- Huh. Gothel was in the tower, trapped by Rapunzel. Why was she named Eloise earlier? I am confused.
+
+```
+-   [Magical whooshing]
+-   Still confused.
+-   This is all a setup, obviously. But on who?
+-   Pirates playing dice with EQ!
+-   AliceTilly is the daughter. EloiseGothel is the mom. altHook is the dad. Got it.
+-   “Officers, may I have a minute?” No, you may not.
+-   Miss Scarlet, with the business card, in the office.
+```
+
+#### S7:E8 Pretty in Blue
+
+“Henry and Ella follow Alice into Wonderland.”  
+Airdate: November 17, 2017
+
+- Training montage!
+- “And other places”
+- Maybe don’t trust her right away?
+- His heart is poisoned? Since when?
+- Many such journeys are possible. Let me be your gateway.
+- “Mecker House”
+- Who are we talking about here, who’s the dangerous law school graduate?
+- Oh, here comes Ivy when Henry is down and out.
+- “Have you ever considered making your blog into a podcast,” asked 2017.
+- Danger Cake of Danger.
+- “Bizarre Love Triangle”, the best is Temptation, of course.
+- Caught in an Ewok trap! Han, can you reach my lightsaber?
+- Don’t land on the sword!
+- “You ever think you’re a bit naive, Henry?” That’s kind of Henry’s entire thing.
+- “A classic Kathryn Nolan situation.”
+- Mister Worm, can you help me enter the labyrinth? No, I’m just a worm.
+- How long until the Drink Me potion regenerates?
+- Good dress!
+- “He’s out being a shady, treacherous bastard somewhere.”
+- Roni’s shirt of the day: “Kid for rent cheap”
+- Wait, why is Eloise back in the machine room?
+- “Walrus and Company”
+- Something is up with Nick. And the so-called missing document.
+- There’s a Star Wars backpack at the tea party.
+- Slain by the Jabberwocky.
+- This is the first we’re hearing of the Curse of the Poisoned Heart, is it not?
+- (Still not a food truck)
+- Ah, that’s why there’s no court order. Rough.
+- Roni tends to be her best customer these days.
+- “You’re always awake.”
+- He’s not admitting it. And you can see he’s struggling.
+- Can’t believe Henry pulled out the “slimy no-good swindler” line!
+- Four beers in.
+- “Someone Victoria Belfrey pushed out” and we’re being obtuse with the pronouns. Who are we going to see in SF?
+- Remy. The caterer. Of course.
+- A mix tape! She made him a mix tape.
+- The coffin is empty. Surprise!

--- a/src/content/ouatrevisit/2023-06-21-ouatrevisit-s7e910.md
+++ b/src/content/ouatrevisit/2023-06-21-ouatrevisit-s7e910.md
@@ -1,0 +1,103 @@
+---
+title: "#OUaTrevisit: S7:E9/10"
+date: 2023-06-21
+description: "Did you correctly guess the Shocking Twists and Surprising Backstories from this week’s episodes? I didn’t, but I’m half-checked out."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s7-e9-10-420446debc36"
+---
+
+### #OUaTrevisit: S7:E9/10
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+Did you correctly guess the Shocking Twists and Surprising Backstories from this week’s pair of episodes? I didn’t, but honestly, I’m half-checked out now.
+
+#### S7:E9 One Little Tear
+
+“Lady Tremaine’s surprising backstory is revealed.”  
+Airdate: December 8, 2017
+
+- See, she used to be a spy…
+- The opening has the floating luminaries from Tangled.
+- We assume this is Actual Rapunzel in the carriage and not Disguised Gothel.
+- Rapunzel is trapped in a CGI studio!
+- She was screaming for Anastasia and Drizella. Another sister? Or something else?
+- IvyDrizella with the primo snark: “Orange better on the women in that Netflix show.”
+- “This isn’t the first time someone’s tried to lock me up,” says Victoria, as we lead into her Surprising Backstory.
+- The building with the ocean mural is familiar to me but I can’t place it.
+- Were we going to find out about Roni’s mysterious friend?
+- (Dearie)
+- WeaverRumple is still hiding his wakefulness. For now.
+- Wait what? Victoria is Rapunzel? Okay, that Backstory is actually Surprising.
+- Convenient ceiling hook.
+- “There is no catch,” says the woman who is most certainly lying.
+- I bet Dad has remarried.
+- Ouch. Rough.
+- “Drizzy”
+
+```
+-   “When you left…” She was *kidnapped* bro.
+-   I wouldn’t have tossed the poisonous mushroom into the fire, myself.
+-   “There’s always my way.”
+-   The old fake-fire-alarm-breaking-into-the-evidence-locker trick.
+-   The Hook!
+-   No, it’s still an empty panel truck. Not a food truck.
+-   “Something out of a Tim Burton movie.”
+-   Looks like Rapunzel tried to cut her wrists at some point.
+-   Rapunzel is catering her daughter’s birthday party. Difficult.
+-   Today I realized Lucy is Rumple’s great-granddaughter. Of course, she’s Henry’s daughter, I just hadn’t put it together.
+-   The Original Book. Wielded by Evil Rapunzel.
+-   Do you want to build a snowman?
+-   Let it go?
+-   Anastasia is the Guardian??
+```
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*c1bP4EK6C_jj3eLS_65LTQ.gif)
+*Not that Anastasia.*
+
+- It sure looked like Rapunzel disintegrated Gothel.
+- Belle is dead, is she not?
+- Anastasia awakens and immediately recognizes Victoria Tremaine Belfrey as her mother, though Gabrielle Anwar and Meegan Warner really don’t resemble each other at all.
+
+#### S7:E10 The Eighth Witch
+
+“Drizella threatens the realm with a dark curse.”  
+Airdate: December 15, 2017
+
+- More witches!
+- Drizella is a Weeping Angel. I believe it.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*CfmO-cOH1DbVuDUBL8sOeQ.gif)
+*That which is the image of an Angel becomes an Angel.*
+
+- The opening sequence has moved from Seattle to San Francisco. Two days on the Amtrak Coast Starlight.
+- You never say that, Tiana! Haven’t you ever seen a movie?
+- The quick cuts are disorienting which I’m sure is the point.
+- Finally! Who are we here to see? I think that’s the vial of curse-canceller potion.
+- It’s funny how this part of San Francisco looks exactly like Granville Island.
+- Spin instructor Kelly: it’s Zelena! (I should have figured that out.)
+- “Cycling monkeys”
+- Emerald Acres Farm. No place like home.
+- Baby Robin, is not a baby anymore. With her father’s aim. 🏹
+- The symbol on the coin is the same one that bruiser had on his arm.
+- Just a little bit of emerald on Zelena’s earrings.
+- Roni’s shirt today is a classic Ramones design.
+- Why has Rumple reverted to troll version?
+- Alice will lose…who? I’m getting lost in the relationships again.
+- “I was cursed! To be a hippie!!”
+- This looks like the Author’s pen test.
+- Heroes! Of course, Zelena has been Team Hero for a while now but it’s great to hear her way it.
+- Oh uh, hey Tiger Lily, nice to see you.
+- A tiny little axe is going to have a hard time with a big old magical tree.
+- Oh, this is the bit we saw from the end of season six.
+- Do we get to see the other witches?
+- Drizella is monologuing. Even though she said she wouldn’t.
+- Regina doing the force-choke move here.
+- Ooh. This is the trap. If the curse is broken, Henry dies from the poison.
+- “You need to calm down.”
+- Oh dang! She knocked Gothel entirely out. But IvyDrizella tricks her. Of course.
+- I wonder if Regina left herself a back door in the curse. She’s cast it so many times, she might be able to slip in a little something extra without Drizella noticing.
+- Alice and Robin!!
+- Where is Robin in the cursed land? We haven’t seen her yet. Have we?
+- Huh. Didn’t work. Too easy.
+- Oops, Drizella was out-evilled. Now Anastasia has all of Drizella’s magic plus her own. But Gothel needs to convince her to use it, right?

--- a/src/content/ouatrevisit/2023-06-28-ouatrevisit-s7e1112.md
+++ b/src/content/ouatrevisit/2023-06-28-ouatrevisit-s7e1112.md
@@ -1,0 +1,119 @@
+---
+title: "#OUaTrevisit: S7:E11/12"
+date: 2023-06-28
+description: "[Magical Whooshing]"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s7-e11-12-741e40bfe5f0"
+---
+
+### #OUaTrevisit: S7:E11/12
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+```
+[Magical Whooshing]
+```
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*sbAGb5WcrXHXCBXzhozw3A.jpeg)
+
+```
+*[Whooshing]*
+```
+
+#### S7:E11 Secret Garden
+
+“Robin seeks guidance from a dangerous source.”  
+Airdate: March 2, 2018
+
+- We haven’t yet seen Cursed Realm Robin, have we? KellyZelena said she’s at a “foam party in Phuket.”
+- Robin is a witch? Lol no, it’s The Craft cosplay. In Regina’s vault no less.
+- Not nice, Robin.
+
+```
+-   [Magical Whooshing]
+-   Remember, this is altHook. The show has given up on characterizing altHook any differently than the familiar primeHook.
+-   Doctor Strange portal. And that was totally Madame Leota in the opening montage.
+-   I don’t believe in the no-win scenario.
+```
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*15tSKvNNsV5h1ddahnbpFQ.gif)
+
+- Pulled up by her arms like that will be excruciating. Probably dislocate the shoulders.
+- Zelena vs Gothel in the amazing hair-off.
+- “Dirty hippie witch bitch”
+- What is the Resurrection Amulet?
+- The spell summons Mother Nature. Could have just tried fake butter.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*oNEO-IVFsFKRnJQpeKXeKQ.gif)
+
+- “Nook”
+- She was seduced by the dark side…
+- “The truth is a complicated companion.”
+- “Doctor Sage” seems familiar?
+- Great shot, kid!
+- The bar used to be Kelly’s before it was Roni’s.
+- “Woodland home of a couple of swirly chipmunks”
+- The invisible witch shop is pretty neat.
+- It is Madame Leota!! Chilling challenge!
+- “Mother knows best”
+- BelfreyRapunzel really tried to appeal to IvyDrizella at this point. After a lifetime of pushing her away. Nah.
+- Another Doctor Strange reference.
+- Apollo bar!
+- altHook has a knack for inspiring speeches.
+- “Kelly & Roni’s Pub”
+- How did the Resurrection Amulet come to be embedded in the pub sign? Everything here was done by the Curse. Maybe this is Regina’s failsafe.
+- Most of this stuff was in Gold’s shop. That’s his old cash register.
+- Oh good, a pentagram on the floor. That always ends well.
+- Robin doesn’t realize she’s the sacrifice. Oops!
+- “I know what you’re thinking, did she shoot six arrows or only five?”
+- I think “Sanctuary” used this same greenhouse.
+- (Dearie)
+- The Beyonce/Blue Ivy/Jay-Z stuff was cute.
+- How Zelena Got Her Groove Back
+- Do we believe Victoria sacrificing herself? No, we don’t.
+- Huh, okay, that’s surprising. Did not expect BelfreyRapunzel to be killed off.
+- Nick, not a match. Henry, confirmed parent. Of course.
+- Doctor Sage was poisoned?!
+
+#### S7:E12 Taste of the Heights
+
+“Tiana confronts Facilier on the day of her coronation.”  
+Airdate: March 9, 2018
+
+- (There’s a Weeping Angel in the background)
+- Henry is doing a podcast.
+- Sabine is going to run the food truck by herself? That’s a recipe for really long lines.
+- Regina and Facilier have some history?
+- H-Town has those five-star reviews! Smash that like and subscribe.
+- One of the reviews is titled “So many ships, so little time!” 😂
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*v_UmFycoVSLm2Lf-5gI6tA.gif)
+*I will go down with this ship*
+
+- “I will get to your story in an upcoming episode, Remy.”
+- Prince Naveen. Okay.
+- Two Cajun trucks in one food truck meet.
+- “The voodoo witch doctor with the ridiculous hat!”
+- Regina scheming with Zelena is the best part of season 7.
+- Why would breaking the curse cause Henry’s magical poison to activate? A broken curse doesn’t send them back to the magical realm, it just lets them remember their past. Henry will remember being poisoned but there’s still (almost) no magic here to make the poison work.
+- Hilda, the blind baker. Perhaps the Hansel and Gretel witch? Different actress though.
+- She has the coven tattoo!
+- Did Sabine ever get a license and permit for her truck?
+- Ah, Mr. Samdi. The silent partner.
+- It’s funny how this scene is Tiana and Naveen but it’s blocked and set like Ariel and Eric. (Kiss the girl!)
+- The Roni/Kelly switch is a test. Did he pass or fail?
+- Mixtape!
+- This reminds me of a terrible, awful movie called Lake Placid.
+- No, you can’t just transfer a food safety permit like that.
+- The gator swallowed a bauble. Just like the croc swallowed a watch.
+
+```
+-   [Magical Whooshing]
+-   “Someone’s killing witches.” “Well pour some sugar on me.” 💀
+-   Something is in Lucy’s closet. Did she line up the plush animals?
+```
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*5_Q8q3kGmgqoHwyig-IUXg.gif)
+
+- I think Regina knows something about the necklace.
+- Okay… Shocking twist. Regina’s dalliance with Facilier must have been back when she was Evil, so pre-Robin.

--- a/src/content/ouatrevisit/2023-07-05-ouatrevisit-s7e1314.md
+++ b/src/content/ouatrevisit/2023-07-05-ouatrevisit-s7e1314.md
@@ -1,0 +1,124 @@
+---
+title: "#OUaTrevisit: S7:E13/14"
+date: 2023-07-05
+description: "We’re still introducing new random characters instead of using the literal pantheon of established ones."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s7-e13-14-cc7fad209d94"
+---
+
+### #OUaTrevisit: S7:E13/14
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+We’re well into the back half of the final season and … we’re still introducing new random characters instead of using the literal pantheon of established ones?
+
+_Note: We’ll be taking next week off and will resume Revisiting in two weeks, on July 19._
+
+#### S7:E13 Knightfall
+
+“Hook confronts Captain Ahab over a magical talisman.”  
+Airdate: March 16, 2018
+
+- Oh good, another one-off character.
+- altHook is visiting his daughter in captivity, that’s nice.
+- I don’t like sand.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*JEOwYM30iFWlSL_kJOXFsw.gif)
+_It’s gritty and it totally gets in your swimsuit._
+
+- The ceremonial exchange of chess pieces.
+- Roni was doing the walk of shame back to her place after her night with Facilier.
+- WeaverRumple gives EloiseGothel the stare of death.
+- Wait, why is primeRumple locked up in the altRealm? Is there more than one Rumple?
+- “One small thing”, sure.
+- (Already bored with Captain Ahab)
+- “Maui’s Fishhook”?? Do we get to learn how Ahab acquired this?
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*xs9o4HiDszbkF695E5LN2Q.gif)
+_We know the way._
+
+- Surprising no one, Hook wins the dice roll.
+- Hey, it’s Sera the Romulan spy.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*cQ4XT_RU2E25oKETw9Epew.gif)
+_Headcanon: Sera is actually IvyDrizella, and JTK and La’an popped in to visit the Cursed Realm._
+
+- Henry is trying so hard to get through to Ivy and she’s just not interested.
+- Is Tilly off her meds?
+- Creepy Gothel waving at the camera.
+- “Are you challenging me to a duel?”
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*6IDzcWoqBnV1n-Pysv8WGw.gif)
+_Yes, if you have the courage!_
+
+- altHook is super easily manipulated by any rando who walks past. Sad, really.
+- This episode is a backdoor pilot for “Gothel, She Wrote.”
+- This is a rare moment of honesty from Ivy.
+- “I’m the damn fool that shot him.”
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*egkJcp6GZA3yaGkaFxaVvQ.gif)
+_Got milk?_
+
+- Tilly didn’t kill the baker, but it looks bad.
+- And now Gothel has Maui’s Fishhook. That can’t be good.
+- Tilly lives in a cargo container.
+- Mochi, from Lucky Cat.
+- Hmm, not sure I’m buying Ivy’s good turn now. Is she trying to break her own curse?
+- Aww, I like Team Regina and Lucy.
+
+#### S7:E14 The Girl in the Tower
+
+“Ivy attempts to make amends with Anastasia.”  
+Air date: March 23, 2018
+
+- How exactly does Alice survive all alone in her tower? Who brings her food? TowerDash?
+- She’s being rescued by a giant troll!
+- Is this the meet-cute of Alice and Robin? ❤️
+- Nobin 😂
+- Gotta have the walkies. Or just iPhones.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*D8jc-xI6n9AkvGthcuREFw.gif)
+_I had these in the early 80s._
+
+- Why can’t KellyZelena know about SamirFacilier? I wonder if there’s some dumb love triangle backstory.
+- It does seem like Ivy is turning over a new leaf, so to speak.
+- “I ran track for three years” in Storybrooke, I guess. Raise your hand if you’d rather have seen “what happened next” in Storybrooke instead of rebooting into a new curse, a new fantasy realm, and new characters.
+- “Two jigsaw puzzles in one box” is an insightful way to describe TillyAlice’s mental difficulties. Might start using that one myself.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*9sWiqABX2-X2UkXREdmB7g.gif)
+_Something about Tilly’s character is really reaching me._
+
+- The old “tape the lock” trick, though very poorly executed.
+- Produce code 4152: McIntosh apples, small.
+- The people at the grocery don’t remember her (anymore?). How sad.
+- “Hippie troll-hugger”
+- Robin stole Emma’s bug! I want to see more of the missing years.
+- I wonder how the 5G coverage is in this realm.
+- Oof. Never leave them in the cell.
+- “I usually get the pizza at Belle Notte…”
+- Why was Tilly’s backpack in the trash? Did she somehow think it would remain safely there?
+- “I say we kill the Beast!”
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*dOHPkKBr5cRZoChc-xDhGA.gif)
+_Does Gaston have a lightsaber?_
+
+- Huh. How did Alice do that?? Emma’s bug just shows up like Herbie.
+- “Should’ve used walkie-talkies.”
+- Oh dear, Tilly has the locks of hair from the victims. Is she being framed?
+- The daughter of the Wicked Witch wanted to be Popular. I see what they did there.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*TUD6fxgBth39OrXotqeWuA.gif)
+_(shrug)_
+
+- Ah, this is how the tower came to be wrecked when Regina and Ivy get there later.
+- This version of Alice is quite powerful.
+- Too bad, we could have used the car here in the trackless wilderness.
+- It’s hipster Robin, back from Tibet.
+- Oops, Lucy left her hat. What does Facilier want withRumple’s dagger?
+
+```
+-   The red glow in the troll becomes a security camera. See, kids, omnipresent surveillance is *good*!
+-   “Margot” looks like the REI catalog brought to life.
+```
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*x2uk9yL2OvNdywFhfjTw9Q.gif)

--- a/src/content/ouatrevisit/2023-07-19-ouatrevisit-s7e1516.md
+++ b/src/content/ouatrevisit/2023-07-19-ouatrevisit-s7e1516.md
@@ -1,0 +1,138 @@
+---
+title: "#OUaTrevisit: S7:E15/16"
+date: 2023-07-19
+description: "#OUaTrevisit is back after a week away! Let’s check in on our favorite unnecessary continuation of a completed story."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s7-e15-16-e2fe3f497050"
+---
+
+### #OUaTrevisit: S7:E15/16
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+We’re back after a week away! Let’s check in on our favorite unnecessary continuation of a completed story.
+
+#### S7:E15 Sisterhood
+
+```
+“Drizella attempts to join the Witch’s [sic] Coven.”  
+Airdate: March 30, 2018
+```
+
+- How many Witches make a Coven?
+- Let’s play in the dark woods at night in the rain, seems fine.
+- Good thing Drizella had some lanterns with her. Or can conjure them, I guess.
+- I was about to be impressed that Drizella got the drop on Regina.
+- Spotted in the opening: FLYNN’S BARCADE
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*8oHExD7gjoviZXi_t9oB4Q.jpeg)
+*IYKYK*
+
+- T-Mobile gift bag?
+- A chocolatier with a penchant for theatrics.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*eH4_-OnpC5PkS9DGaawSkA.gif)
+*I don’t know about the Timothee version yet.*
+
+- Hot cocoa with cinnamon, natch.
+- Bros night out!
+- WeaverRumple trying to mend Chip 😭
+- Nice self-defense, Ivy!
+- Galaga, Ms. Pac-Man, Bubble Bobble, Q-Bert, Neo-Geo, a Marvel game (obvs), and look at the Recognizer on the wall. I love this place.
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*zgYrDNOLid_Txw_E2DX73A.jpeg)
+*I miss it is what I’m saying.*
+
+- “I wouldn’t help me either.”
+- More witches! This is kind of a Hunger Games of Coven-ing.
+- The nachos at Roni’s look pretty good.
+- SamdiFacilier has a magic bean. There seems to be an endless supply of these things.
+- Roni’s magenta velvet boots 😻
+- (Didn’t Belle die though?)
+- Disney ought to sell those lampshades.
+- The blonde witch is Gretel. And I guess we’ll meet Hansel at some point.
+- Gretel’s power turns everything into candy!
+- Pinballs: Creature From The Block Lagoon, Taxi, Fun House, Gladiator?
+- “John Hughes outlook”
+- Who’s the next woman gonna be… Oh, of course.
+- Gothel is so tiresome.
+- Is this IvyDrizella really embracing Anastasia or betraying her? The latter.
+- The Candy Killer? Gotta be Hansel.
+- “Anonymous Chocolates”
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*CbZ0T0kdqjitEjPcN75TdQ.gif)
+*Not quite?*
+
+- We’re wagering our entire future on beer pong.
+- What’s SamdiFacilier’s upside in all this? Sacrificing Ana for the bean, and sending Ivy home, gets him what?
+- This is Drizella’s betraying face. Matched by Gretel. But Drizella is much stronger.
+- Gothel has unleashed much more than she realized.
+- IvyDrizella is really trying this now? You’ve burnt that bridge, sister.
+- “You’ve failed, your highness.”
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*AkkaFZ1kEcExxZPWsNvt1Q.gif)
+
+- Wait, so Ana and IvyDrizella are just going to Doctor Strange out of there? Is the curse not broken, Rumple not back with Belle, or is Henry still potentially poisoned?
+
+```
+-   Magic *always* comes with a price, dearie.
+-   I think I still have one of those Flynn’s tokens from ElecTRONica.
+-   Nick is the Candy Killer?? I should have seen it, I guess.
+```
+
+#### S7:E16 Breadcrumbs
+
+“A job may take Henry away from Jacinda and Lucy.”  
+Airdate: April 6, 2018
+
+- “The Cave of the Golden Dragon”, what did the Golden Dragon ever do to you, dude?
+- This is the first I’ve heard of a magic ring that helped Snow and Charming find each other.
+- “If you want to quest after a ring, talk to the expert.”
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*t-ecZRz5SdoTORiVe6w_Mw.gif)
+*Like this guy, for example.*
+
+- Oh hi, RobinMargot.
+- Nick tried to “land an important client and she got away”… meaning his attempt to kill Ivy??
+- I like the Zelena/Lucy interaction.
+- This scene between Jacinda and Henry is one where you can write the end before it starts.
+- “I have made significant changes to my life.”
+- Red scrawled in the margins, bad news.
+- What’s altHook’s game here?
+- Oh hi, Blackbeard.
+- It’s Rumple’s scary dolls!
+- Sneaking aboard in supply barrels seems suboptimal.
+- “Once we know the map is real, we’ll offer the sharks a royal meal.”
+- Henry was WeaverRumple’s favorite character. Funny.
+- Davy Jones’ Locker is literally just a locker? I always thought it was more metaphorical.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*E8f08qujv2XdIuEs5k3hpA.gif)
+
+- It was all a setup! Until somebody turned on the storm effects.
+- Aw, these two. ❤️
+- “Margot, with a T.” “Targo?”
+- Henry is apparently flying “Connectex Airlines”. I guess Oceanic didn’t have a flight.
+- The QR code on Henry’s boarding pass is not valid. Too bad.
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*ZNUXeSf0u9iC1IP-UsiE_A.jpeg)
+*If the show was being made today, the QR code would have been an easter egg.*
+
+- He drove over a piece of glass slipper. Maybe it’s a sign?
+
+```
+-   *Into* the asteroid field??
+```
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*lz-9e44gvoDbXFfW-aMFVw.gif)
+*Shut him up or shut him down*
+
+- Just throw it in! There’s no need for this!!
+- At least he didn’t lose the finger.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*1dtg25czZWLAhVdM_SaYMQ.gif)
+*Just a scratch, Mister Frodo*
+
+- Oh dear, Henry is getting in the serial killer’s car.
+- “I can offer you my heart.” (grabs his own heart out of his chest)
+- NickHanselJack: “I’m not done killing.” 😟🤨
+- “Kelly West” knows exactly who the chocolates are from.

--- a/src/content/ouatrevisit/2023-07-26-ouatrevisit-s7e1718.md
+++ b/src/content/ouatrevisit/2023-07-26-ouatrevisit-s7e1718.md
@@ -1,0 +1,94 @@
+---
+title: "#OUaTrevisit: S7:E17/18"
+date: 2023-07-26
+description: "Welcome back to #OUaTrevisit. We have eighteen Season 7 episodes down, with six to go."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s7-e17-18-100c2ac177a3"
+---
+
+### #OUaTrevisit: S7:E17/18
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+Welcome back to #OUaTrevisit. We have eighteen Season 7 episodes down, with four to go. That’s just two more weeks! This week sees the end of the Candy Killer while KellyZelena reconciles with Chad.
+
+#### S7:E17 Chosen
+
+“The Candy Killer targets its next victim.”  
+Airdate: April 13, 2018
+
+- Apparently, the Candy Killer uses “it” pronouns.
+- Magic cookies come out of the oven already iced.
+- “There are starving children in Arendelle.” (Queen Elsa would never)
+- The Hansel-and-Gretel witch was previously the blind baker, who was murdered by the Candy Killer.
+- Surprised she took out Zelena so quickly.
+- Nice transition shot from Zelena to Jacinda.
+- Mickey pancakes!
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*shl37OMKydODbWAQuZ7Udg.jpeg)
+*I know, this is a waffle.*
+
+- I don’t care for Hansel’s assortment of knives.
+- She called him “Captain” 😮
+- “How does it feel to be chosen before Regina?” 💀
+- Chairs with “H” and “G” carved into their backs.
+- Henry is going along with JackHansel, thinking he’s nuts, but JH is actually awake and remembers.
+- DrewNaveen is awake too? Seems like half of Hyperion Heights knows about the curse.
+- “So I’m supposed to fight a serial killer with a tchotchke?”
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*A7hGW70ifNIHhQumzV9jUA.gif)
+
+- What happened to Zelena’s magic?
+- “First you start with the kindling, then you nurture the flames.” ❤️
+- C’mon, wicked Zelena, do a good thing.
+- Nick gave Lucy the gingerbread house kit. Creepy.
+- “I’ve been tied to enough trees with you to know these ropes won’t hold.”
+- Candy Crush. Clever.
+- “Boo-bear”
+- “There’s no such thing as a good witch.” “There could be…”
+- Ooh, Zelena is the one who burned Hansel. I’d be pretty upset about that too.
+- “So Nick, is Jack, is Hansel. Must be a bitch keeping track of your driver's licenses.”
+- KellyZelena is a pretty badass bar brawler even without magic.
+- Why does Roni have handcuffs? Hmm.
+- Wow, go Chad!
+- Evil beignets?
+- LOL at the bicycle on the wall.
+- (Monkey)
+- These two guys teaming up can’t be good.
+- Oops. Bye, NickJackHansel.
+
+#### S7:E18 The Guardian
+
+“Weaver sets out to get the Dark One Dagger back.”  
+Airdate: April 20, 2018
+
+- When did WeaverRumple lose the Evil Dagger Of Infinite Evil?
+- Rumple has an entire Dia De Los Muertos shrine dedicated to Belle. Are we getting a Coco (2017) tie-in?
+- If you come at the Dark One, you’d best not miss.
+- Will the camera show SamdiFacilier? Oops, dagger gone.
+- Ugh, these two are so cute. ❤️
+- Robin’s Postal Service
+- Rumple is here to test Alice. Did he bring the box?
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*TJviUMQCaN0hbcC-vA-_6g.gif)
+
+- AltHook is sort of overprotective but also kind of a jerk.
+- It looks like DrewNaveen drove SamdiFacilier to kill NickJackHansel.
+- Double, Double, Toil and Trouble
+- “Don’t do anything crazy” she says to the Evil Dark One Of Evil Darkness.
+- “Mom and Pop bookshop” “Actually it’s Pop and Pop”
+- SamdiFacilier has a crocodile (alligator?) skull in his office.
+- How did Alice do that??
+- Rumple is starting to sound like old Dark One Rumple.
+- Huh, SamdiFacilier has some magic in Hyperion Heights.
+- Fire Escape chase!
+- Almost. Why did he stop her??
+- “Immortality is just another tower.”
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*wsNgyABLuMZk6DHCZ0Qd7Q.jpeg)
+
+- Sad Rumple is sad.
+- Maybe put it somewhere safer this time?
+- Stabbed through the heart, and you’re to blame…
+- There’s no way Jacinda’s apartment has a fireplace.
+- The secret is out. Henry is Lucy’s father. How will Jacinda reconcile this with her memories?

--- a/src/content/ouatrevisit/2023-08-01-ouatrevisit-s7e1920.md
+++ b/src/content/ouatrevisit/2023-08-01-ouatrevisit-s7e1920.md
@@ -1,0 +1,101 @@
+---
+title: "#OUaTrevisit: S7:E19/20"
+date: 2023-08-01
+description: "Only 4 eps to go in this final season of #OnceUponATime, and we are definitely getting the sense of frantically wrapping up storylines."
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s7-e19-20-eb33975289f5"
+---
+
+### #OUaTrevisit: S7:E19/20
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+Only four episodes to go in this final season of #OnceUponATime, and we are definitely getting the sense of frantically wrapping up storylines.
+
+Next week: THE END!
+
+#### S07E19 Flower Child
+
+“Rogers tries to protect Tilly from her mother’s plans.”  
+Airdate, April 27, 2018
+
+- I guess Yarrow is Gothel’s younger sister. We’re looking at ball gowns in a meta-Cinderella scene.
+- I think Gothel just got jumped into the sorority.
+- “He’s just a cop who can’t say no, he’s in a terrible fix…”
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*irLuDhH4I5mjri2UpSupJg.jpeg)
+*He always says “Uh, okay evil coven” just when he oughtta say “Nix”.*
+
+- “You ever been to Cabo?” Ugh, Henry.
+- This whole scene is kind of cringe.
+- DrewNaveen bailed? Or didn’t make bail?
+- “What the hell am I doing here? I don’t belong here.”
+- I have decided on my new front door. Ideally with a glowing anti-solicitor shield.
+- Gothel is actually a “tree nymph”, okay, sure.
+- These outfits on the tree nymphs look like someone went down to Spirit Halloween and grabbed last year’s elf costumes from the clearance shelf.
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*sS0_cWSmcrMmtN28nJ2IzQ.jpeg)
+
+- Gothel and Tilly haven’t met in this world, yet, until now. But come on Tilly, don’t buy this sob story.
+- “I broke into your apartment, charming Monique was nothing.”
+- SamdiFacilier trying to redeem himself with Lucy?
+- Rule number one: Tilly is never wrong.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*HT-GQSpXA-kpThAfH4M3Dg.gif)
+
+- Something terrible is about to happen to Gothel, which will doubtless explain her tragic backstory.
+
+```
+-   [Magical Whooshing]
+-   Cinderella + Carrie. This is going to end well for the sorority.
+-   I love Henry’s conspiracy board!
+```
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*Be3TFvqqIa9A1BF3OViQiQ.gif)
+*Earlier: Lily’s conspiracy board.*
+
+- “Shady women” entering the Hyperion Theater. Matinee show of Rogers?
+- “B.L.” = “before Lucy”
+- Granny’s Diner t-shirt. And the other piece of glass slipper.
+- The Shire has been Scoured.
+- Feed me, Seymour!
+- (said in Batman ’66 announcer voice) Pondering the Persistent Parade of the Impossible?
+- Desk Sergeant Willoughby here is about to be sacrificed, I expect.
+- So our world was once Gothel’s homeland. Okay.
+- SamdiFacilier is now armed with Mighty Joint!
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*KGB6vQCuHQqcO3Ytbcp3Mw.gif)
+*These people don’t know the value.*
+
+- Hmm. TLK didn’t work?
+- This summoning circle bit didn’t turn out so well when the Romulans did it.
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*rsI--VWUwwDWvxKmLndfkw.jpeg)
+*Zhat Vash*
+
+#### S7:E20 Is This Henry Mills?
+
+“In flashback, Henry struggles at deciding his path.”  
+Airdate: May 4, 2018
+
+- “You’re wiping out humanity with a rainstorm, how biblical”
+- Regina: you may think you’re so powerful, well this is my dream!
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*PKRogUvXvkMpfPD7YT4FnA.gif)
+*(RIP Murphy 2.0)*
+
+- Hey, it’s original Henry!
+- The TRON lunchbox. With Regina’s car key!
+- Regina seems legitimately shocked that Henry might not want to stay in Storybrooke.
+- How does Desk Sergeant Dumdum know all this?
+- Storybrooke Regina could snap her fingers and fix the car.
+- Did I freeze frame to get a shot of Henry’s conspiracy board? Yes, I did.
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*wnBXhe-BujwXtyuWP8MAUQ.jpeg)
+*I guess the folks in the background are from the production crew. Nice easter eggs.*
+
+- When you’ve just dosed someone and it didn’t take, maybe don’t stare at them like that.
+- I’ve finally figured out approximately where in Vancouver the exterior shots are located. The BMO Marathon course runs right past it.
+- WeaverRumple’s hair and accent are getting closer to Mr. Gold. And RogersAltHook just said “Aye”.
+
+Are you ready for #OUaTrevisit to end? Am I ready? Next week!

--- a/src/content/ouatrevisit/2023-08-08-ouatrevisit-s7e2122.md
+++ b/src/content/ouatrevisit/2023-08-08-ouatrevisit-s7e2122.md
@@ -1,0 +1,157 @@
+---
+title: "#OUaTrevisit: S7:E21/22"
+date: 2023-08-08
+description: "This is it: the end of #OUaTrevisit. After two years and 155 episodes, we’re done!"
+tags: ["ouatrevisit", "tv", "once-upon-a-time"]
+mediumUrl: "https://medium.com/@smartwatermelon/ouatrevisit-s7-e21-22-f7f018d953c6"
+---
+
+### #OUaTrevisit: S7:E21/22
+
+> This will be posted to [my Mastodon account](https://worldkey.io/@smartwatermelon); don’t forget to read my fellow Revisitors [Katie](https://twitter.com/metzger_katie)’s and [Cindy](https://mastodon.social/@cstephens2)’s posts too!
+
+Well, #OUaTrevisit friends, this is it. We've reached the end. It’s been [nearly two years](https://twitter.com/smartwatermelon/status/1458679081407434752) of two-episodes-per-week stream-of-consciousness summaries; now, that’s right, the last two #OnceUponATime episodes.
+
+[Cindy](https://twitter.com/cstephens2/status/1456766707628838913), [Katie](https://twitter.com/metzger_katie/status/1458981756279799809), and I started this in November of 2021 on the service formerly known as Twitter (I abandoned Twitter as a response to the new owner reinstating the criminal former president, among other outrages). We didn’t have any specific rules about format or description, but this was meant to be a “revisit” rather than a “rewatch” — interestingly, none of us had watched the series to completion during its initial run on ABC.
+
+The only guidelines were: Watch two episodes per week. Write something about what we thought. Post it on Wednesday night. With a few breaks (for vacations, family stuff, etc) we’ve kept it up for 155 episodes over almost two years.
+
+I used Twitter threads for a while, just one tweet after another. Later, I found [this neat tool](https://threadcreator.com/) that lets you draft and schedule threads. Eventually, I moved my revisits here to Medium and used [Buffer](https://buffer.com/) to schedule a post to [Mastodon](https://worldkey.io/@smartwatermelon).
+
+With that bit of historical context, let’s dive into our last revisit!
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*He8dhMOHo7WXOU0HB7_NGg.gif)
+*Dive in, get it?*
+
+#### S7:E21 Homecoming
+
+“Henry and family go on a mission to the Wish Realm.”  
+Airdate: May 11, 2018
+
+- Where’d Graduate Henry get the fantasy gear? Wait, this isn’t Graduate Henry, is it?
+- This feels like a quest from someone else’s story. And who are these people?
+- (Dearie)
+- I’ll be there for you
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*YiupUvoxpFblYX_8zZyIlA.gif)
+
+- A little party at the bar for all the people who woke up.
+- “Starfish”
+- Thanks, adult Henry, for the reminder about why we’re in season 7.
+- Wish noise!
+- This is confirmation that the Henry we saw in the first scene is not Graduate Henry. Probably altHenry, I guess.
+- “We don’t negotiate with villains.”
+- TianaSabine seems to be not thrilled about the broken curse.
+- “Amongst other things…”
+- “We’re all with you ’til the end… which is next week.”
+- Pan??
+- Brutal flashback.
+- I love altHook’s hideout! Looks straight out of PotC (the Disneyland version, thank you).
+- Who’s the good friend? Ariel!!
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*GCpTzGRusgC7OIHVwiHaag.gif)
+*I’m just glad we got one more visit from JoAnna García Swisher before the end.*
+
+- Queen Ariel? She has the Trident.
+- Cruella?! She was in Hell, but I guess this is wishCruella.
+- The dungeon has a Foosball table.
+- Kind of a low blow from Henry. Sure he’s upset, but don’t be mean. We don’t need to be mean.
+
+- The library scene looks like the Stephen J. Cannell Productions tag.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*P-mF6W_-7PjuPsJAnOw_nw.gif)
+*If you remember this, well, it’s time for bed.*
+
+- “I didn’t come here to revisit” (looks at Katie and Cindy)
+- WeaverRumple has a good point. WishRumple taking the Dagger makes sense.
+- Oops, it was a trap for WishRumple. That’s why WeaverRumple needed the squid ink.
+- And then Regina messed it up!
+- Hey, remember the Seer from season 1? With the creepy eye-hands.
+- Henry, that probably killed AltHook or gave him permanent brain damage.
+- Hello, Apprentice.
+- “The timelines alone would make one’s head spin.” You aren’t kidding!
+- True Rewards Await Those Who Choose Wisely
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*GmZGdg4DMgzhb8HqufJKRQ.jpeg)
+*If you remember this, well, it’s time for your back pain pills.*
+
+- “Dalmatian is a bitch to clean”
+- Wow, he harvested her hair color! Cruella’s black hair was colored with magic ink. Okay, sure.
+- This is the Henry from Regina’s Wish Realm. I frankly was not expecting that twist.
+- The powers of the Guardian are no more. Did we ever know who the Guardian actually was? Wasn’t it TillyAlice?
+- “If it comes with a built-in Margot, that’s all I need.” ❤️
+- Remy comes through with a magic bean. *Deus ex Culina,* you might say.
+- We need to get help from some friends. In Storybrooke!
+
+It’s time for the final episode! Cindy, Katie, and I are watching this together, via [Disney+ GroupWatch](https://help.disneyplus.com/csp?id=csp_article_content&sys_kb_id=337dc36c8771291084ab433d0ebb3585).
+
+#### S7:E22 Leaving Storybrooke
+
+“Wish Rumple’s evil plan is revealed.”  
+Airdate: May 18, 2018
+
+- Didn’t Tilly and Margot use their one bean to get back to Storybrooke? How do they plan to transit to Wish Realm?
+- “We’ve been through this before,” says Grumpy, who hasn’t changed a bit.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*q06VvWePi8UU9r-XvjT5qQ.gif)
+
+- Adult Robin and child Robin meeting.
+- Good thing there’s a cabin in the snow globe?
+- Regina killed wishSnow and wishCharming when she thought the Wish Realm wouldn’t last. But it did. Oops, in retrospect.
+- Dark Henry is not buying it.
+- Dad Robin?!
+- “I’m also in here.” (cops a feel)
+- I remember this scene from the Simpsons Movie.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*faQiTbV42bwwl4X0SUZC1w.gif)
+
+- Maui’s hook? I’ve actually forgotten who had that.
+- Oh dear, what’s going to happen to Blue?
+- Everybody gets their own book. Belle would be happy.
+- MargotRobin asks AltHook for TillyAlice’s hand. ❤️
+- AltHook: Leeroy Jenkins!!
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*e5NiuubNoYiaLBCZsdgTUg.gif)
+
+- Are they having their war council in WishHenry’s castle? I missed when Ben Stone and Judy Hopps, I mean Charming and Snow, won that battle.
+- (Where is Emma?)
+- Good thing this Rumple saved *another* piece of magic for emergencies.
+- Everyone going to their own private dungeon. Seems bad. We need a bonus hero.
+- Regina’s speech convinced Dark Henry to not kill her, so his heart isn’t darkened, so the spell failed.
+- Are we saying the whole seven-season series is about Rumple’s redemption?? And Regina’s, I guess?
+- A heart transplant from Rumple to altHook. Well played. Redeeming himself in the end.
+- “Mr. Stark, I don’t feel so good.” (Important: In our group chat, Katie and I said this exact thing at the exact same time.)
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*nGLHdveQtkMuqkcaz8k5wQ.gif)
+*Spoilers for a movie from 2018 I guess?*
+
+- Rumple finally gets the happy ending with Belle.
+- The Henries are now working together?
+- We can all be together including all the ones who are at war with each other. That should be fine.
+- Lily’s father is Zorro??!! Just a random cute throwaway line.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*tm6yZhiVW-7M96QDFE0cNw.gif)
+
+- Young Henry is the Sheriff of Combobrooke.
+- Is everyone who has ever been in the show in this room? Except Emma.
+- Elected Queen. A peaceful transfer of power. Imagine that.
+- There’s Emma and Captain Guyliner! And baby Hope.
+- “This isn’t an ending…” because we’re gonna do season 8! (No)
+- Previously, on Once Upon A Time… everything happened.
+- And… We’re out. Thanks, everyone!
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*68hHHe4j51Od-W-u5yZHPg.gif)
+
+Well. That was a *journey.* Knowing what I know now, am I sorry I watched the entire series, including the sixth and seventh seasons I’d skipped the first time around? No, I’m definitely not sorry. There was real, good, solid storytelling and character development. But of course, there were also plenty of nonsensical writing and plot choices. And the very unnecessary “land of purgatory” and “land of untold stories” diversions were regrettable.  
+But, again, I am glad we did it. I’d had a little bit of regret about bailing on the series after season five, and I enjoyed revisiting the best parts of those first five seasons as well as seeing how the stories resolved by the end of season six. And there was also season seven, for some reason.
+
+Thank you to everyone who has followed along for nearly two years.
+
+Thank you, Katie and Cindy, for being the best Revisit team members I could ask for.
+
+![Screenshot from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*Dhda1np9hVUWDWU7gVpk-A.jpeg)
+*None of us were worthy to lift the hammer, er, Excalibur*
+
+Thank you to my wife Jen for watching nearly every episode with me, for putting up with my grumbling about dumb plots and my rewinding to catch easter eggs, for catching up on episodes when one or the other of us was traveling so we wouldn’t be out of sync, and for generally being the Emma to my Neal.
+
+![Reaction GIF from Once Upon a Time Season 7 recap](https://cdn-images-1.medium.com/max/800/1*ok6L4zTbonMcoXkPdDDxjQ.gif)

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,50 @@
+---
+import '../styles/global.css';
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description = 'Personal site of Andrew Rich — hacker, veteran, IRONMAN, friend to cats.' } = Astro.props;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="sitemap" href="/sitemap-index.xml" />
+    <link rel="canonical" href={canonicalURL} />
+    <meta name="description" content={description} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalURL} />
+    <title>{title} — Project Insomnia</title>
+  </head>
+  <body>
+    <header>
+      <nav>
+        <a href="/" class="site-name">Project Insomnia</a>
+        <ul>
+          <li><a href="/blog/">Blog</a></li>
+          <li><a href="/now/">Now</a></li>
+          <li><a href="/projects/">Projects</a></li>
+          <li><a href="/about/">About</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main>
+      <slot />
+    </main>
+
+    <footer>
+      <p>
+        &copy; {new Date().getFullYear()} Andrew Rich &mdash; Spokane, WA
+      </p>
+    </footer>
+  </body>
+</html>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,0 +1,95 @@
+---
+import BaseLayout from './BaseLayout.astro';
+
+interface Props {
+  title: string;
+  date: Date;
+  description?: string;
+  tags?: string[];
+  mediumUrl?: string;
+  collection: 'blog' | 'ouatrevisit' | 'elections';
+}
+
+const { title, date, description, tags = [], mediumUrl, collection } = Astro.props;
+
+const dateStr = date.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  timeZone: 'UTC',
+});
+
+const backLinks: Record<string, { href: string; label: string }> = {
+  blog: { href: '/blog/', label: '← Blog' },
+  ouatrevisit: { href: '/blog/ouatrevisit/', label: '← Once Upon a Time Revisit' },
+  elections: { href: '/blog/elections/', label: '← Elections' },
+};
+
+const back = backLinks[collection];
+---
+
+<BaseLayout title={title} description={description}>
+  <article>
+    <header class="post-header">
+      <a href={back.href} class="back-link">{back.label}</a>
+      <h1>{title}</h1>
+      <div class="post-meta">
+        <time datetime={date.toISOString()}>{dateStr}</time>
+        {tags.filter(t => !['blog', 'ouatrevisit', 'elections'].includes(t)).map(tag => (
+          <span class="tag">{tag}</span>
+        ))}
+      </div>
+      {mediumUrl && (
+        <p class="medium-note">
+          Originally published on <a href={mediumUrl} rel="noopener noreferrer" target="_blank">Medium</a>.
+        </p>
+      )}
+    </header>
+
+    <div class="prose">
+      <slot />
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .post-header {
+    margin-bottom: 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .back-link {
+    display: inline-block;
+    font-size: 0.85rem;
+    color: var(--color-muted);
+    text-decoration: none;
+    margin-bottom: 1rem;
+  }
+
+  .back-link:hover { color: var(--color-accent); }
+
+  h1 { margin-bottom: 0.75rem; }
+
+  .post-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    color: var(--color-muted);
+    font-size: 0.875rem;
+  }
+
+  .medium-note {
+    margin-top: 0.75rem;
+    font-size: 0.85rem;
+    color: var(--color-muted);
+  }
+
+  .prose { line-height: 1.8; }
+
+  .prose :global(h2:first-child),
+  .prose :global(h3:first-child) {
+    margin-top: 0;
+  }
+</style>

--- a/src/lib/slugFromId.ts
+++ b/src/lib/slugFromId.ts
@@ -1,0 +1,7 @@
+/**
+ * Strip the date prefix and file extension from an Astro 5 content collection ID.
+ * e.g. "2026-01-24-baumgartner-must-go.md" → "baumgartner-must-go"
+ */
+export function slugFromId(id: string): string {
+  return id.replace(/^\d{4}-\d{2}-\d{2}-/, "").replace(/\.mdx?$/, "");
+}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,38 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="About">
+  <h1>About</h1>
+
+  <p>
+    I'm Andrew Rich. I live in Spokane, WA with my spouse Jen and an
+    unreasonable number of cats.
+  </p>
+
+  <p>
+    By day I work in government technology. By night I build things:
+    apps, automations, the occasional ill-advised endurance event.
+  </p>
+
+  <h2>Elsewhere</h2>
+  <ul>
+    <li><a href="https://github.com/andrewrich" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+    <li><a href="https://www.strava.com" rel="noopener noreferrer" target="_blank">Strava</a></li>
+    <li><a href="https://instagram.com/smartwatermelon" rel="noopener noreferrer" target="_blank">Instagram</a></li>
+    <li><a href="https://medium.com/@smartwatermelon" rel="noopener noreferrer" target="_blank">Medium</a> (archived)</li>
+  </ul>
+
+  <h2>This Site</h2>
+  <p>
+    Built with <a href="https://astro.build" target="_blank" rel="noopener noreferrer">Astro</a>,
+    hosted on <a href="https://netlify.com" target="_blank" rel="noopener noreferrer">Netlify</a>.
+    Content migrated from Medium. Source on
+    <a href="https://github.com/andrewrich/projectinsomnia" target="_blank" rel="noopener noreferrer">GitHub</a>.
+  </p>
+
+  <p>
+    "Project Insomnia" has been my personal domain since the early 90s.
+    Some things are worth keeping.
+  </p>
+</BaseLayout>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,27 @@
+---
+import { getCollection, render } from 'astro:content';
+import { slugFromId } from '../../lib/slugFromId';
+import PostLayout from '../../layouts/PostLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map(post => ({
+    params: { slug: slugFromId(post.id) },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<PostLayout
+  title={post.data.title}
+  date={post.data.date}
+  description={post.data.description}
+  tags={post.data.tags}
+  mediumUrl={post.data.mediumUrl}
+  collection="blog"
+>
+  <Content />
+</PostLayout>

--- a/src/pages/blog/elections/[slug].astro
+++ b/src/pages/blog/elections/[slug].astro
@@ -1,0 +1,27 @@
+---
+import { getCollection, render } from 'astro:content';
+import { slugFromId } from '../../../lib/slugFromId';
+import PostLayout from '../../../layouts/PostLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('elections');
+  return posts.map(post => ({
+    params: { slug: slugFromId(post.id) },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<PostLayout
+  title={post.data.title}
+  date={post.data.date}
+  description={post.data.description}
+  tags={post.data.tags}
+  mediumUrl={post.data.mediumUrl}
+  collection="elections"
+>
+  <Content />
+</PostLayout>

--- a/src/pages/blog/elections/index.astro
+++ b/src/pages/blog/elections/index.astro
@@ -1,0 +1,42 @@
+---
+import { getCollection } from 'astro:content';
+import { slugFromId } from '../../../lib/slugFromId';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+
+const posts = (await getCollection('elections'))
+  .filter(p => !p.data.draft)
+  .sort((a, b) => a.data.date.valueOf() - b.data.date.valueOf());
+---
+
+<BaseLayout title="Elections">
+  <h1>Elections</h1>
+  <p class="series-desc">
+    Ballot choices and election night notes, 2014–2024.
+  </p>
+
+  <nav class="section-nav">
+    <a href="/blog/">Blog</a>
+    <a href="/blog/ouatrevisit/">OUaT Revisit</a>
+    <a href="/blog/elections/" class="active">Elections</a>
+  </nav>
+
+  <ul class="post-list">
+    {posts.map(post => (
+      <li>
+        <a href={`/blog/elections/${slugFromId(post.id)}/`}>{post.data.title}</a>
+        <div class="post-meta">
+          <time datetime={post.data.date.toISOString()}>
+            {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
+          </time>
+        </div>
+      </li>
+    ))}
+  </ul>
+</BaseLayout>
+
+<style>
+  .series-desc {
+    color: var(--color-muted);
+    margin-bottom: 2rem;
+  }
+</style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,39 @@
+---
+import { getCollection } from 'astro:content';
+import { slugFromId } from '../../lib/slugFromId';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const posts = (await getCollection('blog'))
+  .filter(p => !p.data.draft)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+---
+
+<BaseLayout title="Blog">
+  <h1>Blog</h1>
+
+  <nav class="section-nav">
+    <a href="/blog/" class="active">All</a>
+    <a href="/blog/ouatrevisit/">Once Upon a Time Revisit</a>
+    <a href="/blog/elections/">Elections</a>
+  </nav>
+
+  <ul class="post-list">
+    {posts.map(post => {
+      const slug = slugFromId(post.id);
+      return (
+        <li>
+          <a href={`/blog/${slug}/`}>{post.data.title}</a>
+          <div class="post-meta">
+            <time datetime={post.data.date.toISOString()}>
+              {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
+            </time>
+            {(post.data.tags ?? [])
+              .filter(t => !['blog', 'ouatrevisit', 'elections'].includes(t))
+              .map(tag => <span class="tag">{tag}</span>)
+            }
+          </div>
+        </li>
+      );
+    })}
+  </ul>
+</BaseLayout>

--- a/src/pages/blog/ouatrevisit/[slug].astro
+++ b/src/pages/blog/ouatrevisit/[slug].astro
@@ -1,0 +1,27 @@
+---
+import { getCollection, render } from 'astro:content';
+import { slugFromId } from '../../../lib/slugFromId';
+import PostLayout from '../../../layouts/PostLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('ouatrevisit');
+  return posts.map(post => ({
+    params: { slug: slugFromId(post.id) },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<PostLayout
+  title={post.data.title}
+  date={post.data.date}
+  description={post.data.description}
+  tags={post.data.tags}
+  mediumUrl={post.data.mediumUrl}
+  collection="ouatrevisit"
+>
+  <Content />
+</PostLayout>

--- a/src/pages/blog/ouatrevisit/index.astro
+++ b/src/pages/blog/ouatrevisit/index.astro
@@ -1,0 +1,43 @@
+---
+import { getCollection } from 'astro:content';
+import { slugFromId } from '../../../lib/slugFromId';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+
+const posts = (await getCollection('ouatrevisit'))
+  .filter(p => !p.data.draft)
+  .sort((a, b) => a.data.date.valueOf() - b.data.date.valueOf());
+---
+
+<BaseLayout title="Once Upon a Time Revisit">
+  <h1>Once Upon a Time Revisit</h1>
+  <p class="series-desc">
+    A rewatch series covering Seasons 4–7, written during the 2020s.
+    Spoilers throughout.
+  </p>
+
+  <nav class="section-nav">
+    <a href="/blog/">Blog</a>
+    <a href="/blog/ouatrevisit/" class="active">OUaT Revisit</a>
+    <a href="/blog/elections/">Elections</a>
+  </nav>
+
+  <ul class="post-list">
+    {posts.map(post => (
+      <li>
+        <a href={`/blog/ouatrevisit/${slugFromId(post.id)}/`}>{post.data.title}</a>
+        <div class="post-meta">
+          <time datetime={post.data.date.toISOString()}>
+            {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
+          </time>
+        </div>
+      </li>
+    ))}
+  </ul>
+</BaseLayout>
+
+<style>
+  .series-desc {
+    color: var(--color-muted);
+    margin-bottom: 2rem;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,53 @@
 ---
+import { getCollection } from 'astro:content';
+import { slugFromId } from '../lib/slugFromId';
+import BaseLayout from '../layouts/BaseLayout.astro';
 
+const posts = (await getCollection('blog'))
+  .filter(p => !p.data.draft)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+  .slice(0, 5);
 ---
 
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<link rel="icon" href="/favicon.ico" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro</title>
-	</head>
-	<body>
-		<h1>Astro</h1>
-	</body>
-</html>
+<BaseLayout title="Home">
+  <section class="intro">
+    <h1>Project Insomnia</h1>
+    <p>
+      Andrew Rich. Hacker, engineer, voice actor, Army vet, nonmammaltarian,
+      IRONMAN, friend to cats. He/Him. Doesn't speak for employer.
+    </p>
+    <p>Based in Spokane, WA.</p>
+  </section>
+
+  <section class="recent-posts">
+    <h2>Recent Posts</h2>
+    <ul class="post-list">
+      {posts.map(post => {
+        const slug = slugFromId(post.id);
+        return (
+          <li>
+            <a href={`/blog/${slug}/`}>{post.data.title}</a>
+            <div class="post-meta">
+              <time datetime={post.data.date.toISOString()}>
+                {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
+              </time>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+    <p><a href="/blog/">All posts →</a></p>
+  </section>
+</BaseLayout>
+
+<style>
+  .intro {
+    margin-bottom: 3rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .intro h1 { margin-bottom: 1rem; }
+
+  .recent-posts h2 { margin-top: 0; }
+</style>

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -1,0 +1,38 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+// Placeholder — activity feed via Netlify scheduled functions comes later
+const lastUpdated = new Date().toLocaleDateString('en-US', {
+  year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC'
+});
+---
+
+<BaseLayout title="Now">
+  <h1>Now</h1>
+  <p class="updated">Last updated {lastUpdated}</p>
+
+  <p>
+    A <a href="https://nownownow.com/about" target="_blank" rel="noopener noreferrer">/now page</a>
+    — what I'm up to at the moment.
+  </p>
+
+  <h2>Work</h2>
+  <p>
+    Day job in government technology. Nights and weekends: building
+    <a href="/projects/">apps</a> under Night Owl Studio, LLC.
+  </p>
+
+  <h2>Training</h2>
+  <p>Strava feed coming soon.</p>
+
+  <h2>Reading / Watching</h2>
+  <p>Fill this in.</p>
+</BaseLayout>
+
+<style>
+  .updated {
+    color: var(--color-muted);
+    font-size: 0.85rem;
+    margin-bottom: 2rem;
+  }
+</style>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,0 +1,48 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Projects">
+  <h1>Projects</h1>
+
+  <div class="project">
+    <h2><a href="https://apps.apple.com/app/kebab" target="_blank" rel="noopener noreferrer">Kebab</a></h2>
+    <p class="project-meta">iOS &amp; Android &mdash; Night Owl Studio, LLC</p>
+    <p>
+      Donation tracker and fair-market-value calculator for charitable giving.
+      Fills the gap left by Intuit's discontinued ItsDeductible. Privacy-first,
+      local data, no ads.
+    </p>
+  </div>
+
+  <div class="project">
+    <h2>crazylarry.space</h2>
+    <p class="project-meta">Web</p>
+    <p>
+      A thing that exists.
+    </p>
+  </div>
+</BaseLayout>
+
+<style>
+  .project {
+    margin-bottom: 2.5rem;
+    padding-bottom: 2.5rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .project:last-child {
+    border-bottom: none;
+  }
+
+  .project h2 {
+    margin-top: 0;
+    margin-bottom: 0.25rem;
+  }
+
+  .project-meta {
+    font-size: 0.85rem;
+    color: var(--color-muted);
+    margin-bottom: 0.75rem;
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,252 @@
+/* ============================================================
+   Project Insomnia — Global Styles
+   ============================================================
+   Variables → Reset → Base → Layout → Typography → Components
+   ============================================================ */
+
+/* Variables
+   ---------------------------------------------------------- */
+:root {
+  --color-bg: #0f0f0f;
+  --color-surface: #1a1a1a;
+  --color-border: #2a2a2a;
+  --color-text: #e0e0e0;
+  --color-muted: #888;
+  --color-accent: #7c6af7;
+  --color-accent-hover: #9d8fff;
+  --font-sans: system-ui, -apple-system, sans-serif;
+  --font-mono: "Fira Code", "Cascadia Code", monospace;
+  --measure: 68ch;
+}
+
+/* Reset
+   ---------------------------------------------------------- */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+/* Base
+   ---------------------------------------------------------- */
+html {
+  font-size: 18px;
+  scroll-behavior: smooth;
+}
+
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  line-height: 1.7;
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+}
+
+/* Layout — Nav
+   ---------------------------------------------------------- */
+header {
+  border-bottom: 1px solid var(--color-border);
+  padding: 1rem 2rem;
+}
+
+nav {
+  max-width: 80rem;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
+.site-name {
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: -0.02em;
+  color: var(--color-accent);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+nav ul {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+}
+
+nav a {
+  color: var(--color-muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: color 0.15s;
+}
+
+nav a:hover {
+  color: var(--color-text);
+}
+
+/* Layout — Main
+   ---------------------------------------------------------- */
+main {
+  max-width: var(--measure);
+  margin: 0 auto;
+  padding: 3rem 2rem;
+  width: 100%;
+}
+
+/* Layout — Footer
+   ---------------------------------------------------------- */
+footer {
+  border-top: 1px solid var(--color-border);
+  padding: 1.5rem 2rem;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+/* Typography
+   ---------------------------------------------------------- */
+h1 {
+  font-size: 2rem;
+  line-height: 1.2;
+  letter-spacing: -0.03em;
+  margin-bottom: 0.5rem;
+}
+h2 {
+  font-size: 1.4rem;
+  line-height: 1.3;
+  letter-spacing: -0.02em;
+  margin: 2rem 0 0.75rem;
+}
+h3 {
+  font-size: 1.15rem;
+  margin: 1.5rem 0 0.5rem;
+}
+
+p {
+  margin-bottom: 1.25rem;
+}
+
+a {
+  color: var(--color-accent);
+}
+a:hover {
+  color: var(--color-accent-hover);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background: var(--color-surface);
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+blockquote {
+  border-left: 3px solid var(--color-accent);
+  padding-left: 1.25rem;
+  color: var(--color-muted);
+  font-style: italic;
+  margin: 1.5rem 0;
+}
+
+ul,
+ol {
+  padding-left: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+li {
+  margin-bottom: 0.25rem;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: 2rem 0;
+}
+
+/* Components — Post List
+   ---------------------------------------------------------- */
+.post-list {
+  list-style: none;
+  padding: 0;
+}
+
+.post-list li {
+  border-bottom: 1px solid var(--color-border);
+  padding: 1.25rem 0;
+}
+
+.post-list li:first-child {
+  padding-top: 0;
+}
+
+.post-list a {
+  text-decoration: none;
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.post-list a:hover {
+  color: var(--color-accent);
+}
+
+.post-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  margin-top: 0.25rem;
+}
+
+/* Components — Tags
+   ---------------------------------------------------------- */
+.tag {
+  display: inline-block;
+  font-size: 0.75rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  padding: 0.1em 0.5em;
+  color: var(--color-muted);
+  text-decoration: none;
+  margin-right: 0.25rem;
+}
+
+/* Components — Section Nav
+   ---------------------------------------------------------- */
+.section-nav {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  font-size: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.section-nav a {
+  color: var(--color-muted);
+  text-decoration: none;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  transition: all 0.15s;
+}
+
+.section-nav a:hover,
+.section-nav a.active {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}


### PR DESCRIPTION
Transforms bare Astro scaffold into a complete personal site for
projectinsomnia.com. Adds MDX/sitemap/expressive-code integrations,
dark-themed global styles, BaseLayout with nav and footer, content
collections for blog/elections/ouatrevisit series, listing and detail
pages with section navigation, and static pages for About, Now, and
Projects. All blog content migrated from Medium archives.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
