### PR TITLE
Switch to cool light theme

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,13 +7,13 @@
 /* Variables
    ---------------------------------------------------------- */
 :root {
-  --color-bg: #0f0f0f;
-  --color-surface: #1a1a1a;
-  --color-border: #2a2a2a;
-  --color-text: #e0e0e0;
-  --color-muted: #888;
-  --color-accent: #7c6af7;
-  --color-accent-hover: #9d8fff;
+  --color-bg: #f4f6f9;
+  --color-surface: #eaecf1;
+  --color-border: #cdd2db;
+  --color-text: #1c2333;
+  --color-muted: #5c6475;
+  --color-accent: #4338ca;
+  --color-accent-hover: #3730a3;
   --font-sans: system-ui, -apple-system, sans-serif;
   --font-mono: "Fira Code", "Cascadia Code", monospace;
   --measure: 68ch;


### PR DESCRIPTION
## Summary
- Replaces temporary dark theme with a cool gray-blue light palette
- All foreground/background pairs meet WCAG AA (4.5:1 contrast minimum)
- Accent color shifted from `#7c6af7` (insufficient contrast on light bg) to `#4338ca` indigo

| Token | Before | After |
|---|---|---|
| `--color-bg` | `#0f0f0f` | `#f4f6f9` |
| `--color-surface` | `#1a1a1a` | `#eaecf1` |
| `--color-border` | `#2a2a2a` | `#cdd2db` |
| `--color-text` | `#e0e0e0` | `#1c2333` |
| `--color-muted` | `#888` | `#5c6475` |
| `--color-accent` | `#7c6af7` | `#4338ca` |
| `--color-accent-hover` | `#9d8fff` | `#3730a3` |

## Test plan
- [ ] Netlify preview looks comfortable on homepage, blog list, post, about, projects
- [ ] Links, tags, section-nav, blockquotes render cleanly
- [ ] Code blocks readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)