### PR TITLE
feat: scheduled blog publishing via future-dated posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,30 @@ Set in Netlify dashboard (not committed):
 | `STRAVA_CLIENT_SECRET` | strava-feed function |
 | `STRAVA_REFRESH_TOKEN` | strava-feed function |
 | `INSTAGRAM_WEBHOOK_SECRET` | instagram-webhook function |
+| `BUILD_HOOK_URL` | scheduled-rebuild function |
+
+## Blog Publishing
+
+Posts use two frontmatter fields to control visibility:
+
+- **`draft: true`** — never published, regardless of date
+- **`date`** — the publish date; future-dated posts are hidden until that date arrives
+
+### Publish modes
+
+| Mode | How | When it goes live |
+| :--- | :-- | :---------------- |
+| Scheduled | Set `date` to a future date, `draft: false`, merge to main | Automatically at ~6am PT on/after that date |
+| Immediate | Set `date` to today, merge, then trigger the build hook | Minutes after triggering |
+| Draft | Set `draft: true` | Never (until you remove the flag) |
+
+### Manual publish trigger
+
+```sh
+curl -sX POST "$BUILD_HOOK_URL"
+```
+
+The build hook URL is stored as `BUILD_HOOK_URL` in Netlify environment variables. A Netlify Scheduled Function triggers a rebuild daily at ~6am PT (1pm UTC) to sweep up any posts whose date has arrived.
 
 ## Development
 

--- a/netlify/functions/scheduled-rebuild.mts
+++ b/netlify/functions/scheduled-rebuild.mts
@@ -1,0 +1,12 @@
+import type { Config } from "@netlify/functions"
+
+export default async () => {
+  const hook = Netlify.env.get("BUILD_HOOK_URL")
+  if (!hook) throw new Error("BUILD_HOOK_URL not set")
+  await fetch(hook, { method: "POST" })
+  return new Response("Build triggered")
+}
+
+export const config: Config = {
+  schedule: "0 13 * * *",
+}

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -4,7 +4,8 @@ import { slugFromId } from '../../lib/slugFromId';
 import PostLayout from '../../layouts/PostLayout.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog', ({ data }) => !data.draft);
+  const now = new Date();
+  const posts = await getCollection('blog', ({ data }) => !data.draft && data.date <= now);
   return posts.map(post => ({
     params: { slug: slugFromId(post.id) },
     props: { post },

--- a/src/pages/blog/elections/[slug].astro
+++ b/src/pages/blog/elections/[slug].astro
@@ -4,7 +4,8 @@ import { slugFromId } from '../../../lib/slugFromId';
 import PostLayout from '../../../layouts/PostLayout.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('elections');
+  const now = new Date();
+  const posts = await getCollection('elections', ({ data }) => !data.draft && data.date <= now);
   return posts.map(post => ({
     params: { slug: slugFromId(post.id) },
     props: { post },

--- a/src/pages/blog/elections/index.astro
+++ b/src/pages/blog/elections/index.astro
@@ -3,8 +3,9 @@ import { getCollection } from 'astro:content';
 import { slugFromId } from '../../../lib/slugFromId';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 
+const now = new Date();
 const posts = (await getCollection('elections'))
-  .filter(p => !p.data.draft)
+  .filter(p => !p.data.draft && p.data.date <= now)
   .sort((a, b) => a.data.date.valueOf() - b.data.date.valueOf());
 ---
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -3,8 +3,9 @@ import { getCollection } from 'astro:content';
 import { slugFromId } from '../../lib/slugFromId';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 
+const now = new Date();
 const posts = (await getCollection('blog'))
-  .filter(p => !p.data.draft)
+  .filter(p => !p.data.draft && p.data.date <= now)
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 ---
 

--- a/src/pages/blog/ouatrevisit/[slug].astro
+++ b/src/pages/blog/ouatrevisit/[slug].astro
@@ -4,7 +4,8 @@ import { slugFromId } from '../../../lib/slugFromId';
 import PostLayout from '../../../layouts/PostLayout.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('ouatrevisit');
+  const now = new Date();
+  const posts = await getCollection('ouatrevisit', ({ data }) => !data.draft && data.date <= now);
   return posts.map(post => ({
     params: { slug: slugFromId(post.id) },
     props: { post },

--- a/src/pages/blog/ouatrevisit/index.astro
+++ b/src/pages/blog/ouatrevisit/index.astro
@@ -3,8 +3,9 @@ import { getCollection } from 'astro:content';
 import { slugFromId } from '../../../lib/slugFromId';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 
+const now = new Date();
 const posts = (await getCollection('ouatrevisit'))
-  .filter(p => !p.data.draft)
+  .filter(p => !p.data.draft && p.data.date <= now)
   .sort((a, b) => a.data.date.valueOf() - b.data.date.valueOf());
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,8 +3,9 @@ import { getCollection } from 'astro:content';
 import { slugFromId } from '../lib/slugFromId';
 import BaseLayout from '../layouts/BaseLayout.astro';
 
+const now = new Date();
 const posts = (await getCollection('blog'))
-  .filter(p => !p.data.draft)
+  .filter(p => !p.data.draft && p.data.date <= now)
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
   .slice(0, 5);
 ---

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,21 +1,28 @@
-import rss from '@astrojs/rss';
-import { getCollection } from 'astro:content';
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
 
 export async function GET(context) {
-  const posts = await getCollection('blog', ({ data }) => !data.draft);
+  const now = new Date();
+  const posts = await getCollection(
+    "blog",
+    ({ data }) => !data.draft && data.date <= now,
+  );
 
   posts.sort((a, b) => b.data.date - a.data.date);
 
   return rss({
-    title: 'Project Insomnia',
-    description: 'Andrew Rich — writing about software, Spokane, and whatever else.',
+    title: "Project Insomnia",
+    description:
+      "Andrew Rich — writing about software, Spokane, and whatever else.",
     site: context.site,
     items: posts.map((post) => {
-      const slug = post.id.replace(/^\d{4}-\d{2}-\d{2}-/, '').replace(/\.mdx?$/, '');
+      const slug = post.id
+        .replace(/^\d{4}-\d{2}-\d{2}-/, "")
+        .replace(/\.mdx?$/, "");
       return {
         title: post.data.title,
         pubDate: post.data.date,
-        description: post.data.description ?? '',
+        description: post.data.description ?? "",
         link: `/blog/${slug}/`,
       };
     }),


### PR DESCRIPTION
## Summary

- Posts with a future `date` are now excluded from the build, just like `draft: true` posts
- A Netlify Scheduled Function (`scheduled-rebuild.mts`) triggers a daily rebuild at ~6am PT (1pm UTC) so queued posts go live automatically
- Manual immediate publishing remains available via `curl -sX POST "$BUILD_HOOK_URL"`

## One-time setup after merge

1. Create a build hook in Netlify Dashboard (Site Settings > Build & Deploy > Build Hooks)
2. Store the URL as `BUILD_HOOK_URL` env var in Netlify

## Test plan

- [ ] Verify build passes (future-dated posts excluded, past-dated posts included)
- [ ] Confirm scheduled function deploys on Netlify
- [ ] Create build hook and set env var
- [ ] Test manual trigger via `curl`
- [ ] Queue a future-dated post and confirm it appears after the next scheduled rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)