### PR TITLE
feat: add weighted tag cloud and tag filtering to /blog

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -36,7 +36,7 @@ const back = backLinks[collection];
       <div class="post-meta">
         <time datetime={date.toISOString()}>{dateStr}</time>
         {tags.filter(t => !['blog', 'ouatrevisit', 'elections'].includes(t)).map(tag => (
-          <span class="tag">{tag}</span>
+          <a href={`/blog/?tag=${encodeURIComponent(tag)}`} class="tag">{tag}</a>
         ))}
       </div>
       {mediumUrl && (

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -3,13 +3,44 @@ import { getCollection } from 'astro:content';
 import { slugFromId } from '../../lib/slugFromId';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 
+export const prerender = false;
+
+const metaTags = ['blog', 'ouatrevisit', 'elections'];
+
 const now = new Date();
-const posts = (await getCollection('blog'))
+const allPosts = (await getCollection('blog'))
   .filter(p => !p.data.draft && p.data.date <= now)
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+// Build tag counts
+const tagCounts = new Map<string, number>();
+for (const post of allPosts) {
+  for (const tag of post.data.tags ?? []) {
+    if (!metaTags.includes(tag)) {
+      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+    }
+  }
+}
+const sortedTags = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+
+// Size buckets based on post count
+const maxCount = Math.max(...tagCounts.values(), 1);
+function tagSize(count: number): string {
+  const ratio = count / maxCount;
+  if (ratio > 0.75) return 'tag-xl';
+  if (ratio > 0.5) return 'tag-lg';
+  if (ratio > 0.25) return 'tag-md';
+  return 'tag-sm';
+}
+
+// Filter by active tag
+const activeTag = Astro.url.searchParams.get('tag');
+const posts = activeTag
+  ? allPosts.filter(p => (p.data.tags ?? []).includes(activeTag))
+  : allPosts;
 ---
 
-<BaseLayout title="Blog">
+<BaseLayout title={activeTag ? `Blog — #${activeTag}` : 'Blog'}>
   <h1>Blog</h1>
 
   <nav class="section-nav">
@@ -17,6 +48,22 @@ const posts = (await getCollection('blog'))
     <a href="/blog/ouatrevisit/">Once Upon a Time Revisit</a>
     <a href="/blog/elections/">Elections</a>
   </nav>
+
+  <div class="tag-cloud">
+    {sortedTags.map(([tag, count]) => (
+      <a
+        href={`/blog/?tag=${encodeURIComponent(tag)}`}
+        class:list={['tag', tagSize(count), { active: tag === activeTag }]}
+      >{tag}</a>
+    ))}
+  </div>
+
+  {activeTag && (
+    <div class="tag-filter-status">
+      Showing posts tagged <strong>{activeTag}</strong>
+      <a href="/blog/" class="clear-filter">clear</a>
+    </div>
+  )}
 
   <ul class="post-list">
     {posts.map(post => {
@@ -29,8 +76,10 @@ const posts = (await getCollection('blog'))
               {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
             </time>
             {(post.data.tags ?? [])
-              .filter(t => !['blog', 'ouatrevisit', 'elections'].includes(t))
-              .map(tag => <span class="tag">{tag}</span>)
+              .filter(t => !metaTags.includes(t))
+              .map(tag => (
+                <a href={`/blog/?tag=${encodeURIComponent(tag)}`} class="tag">{tag}</a>
+              ))
             }
           </div>
         </li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -234,6 +234,54 @@ hr {
   margin-right: 0.25rem;
 }
 
+a.tag:hover {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+a.tag.active {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+
+/* Components — Tag Cloud
+   ---------------------------------------------------------- */
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 1.5rem;
+  align-items: baseline;
+}
+
+.tag-cloud .tag-sm {
+  font-size: 0.75rem;
+}
+.tag-cloud .tag-md {
+  font-size: 0.9rem;
+}
+.tag-cloud .tag-lg {
+  font-size: 1.1rem;
+}
+.tag-cloud .tag-xl {
+  font-size: 1.3rem;
+}
+
+/* Components — Tag Filter Status
+   ---------------------------------------------------------- */
+.tag-filter-status {
+  font-size: 0.875rem;
+  color: var(--color-muted);
+  margin-bottom: 1rem;
+}
+
+.clear-filter {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--color-accent);
+}
+
 /* Components — Section Nav
    ---------------------------------------------------------- */
 .section-nav {


### PR DESCRIPTION
## Summary
- Adds a weighted tag cloud to the `/blog` index page — tags sized by frequency, sorted alphabetically
- Tags on posts (both in the blog list and individual post headers) are now clickable links to `/blog/?tag=<tag>`
- Filtering shows a "clear" link to return to the full list; page title updates to reflect the active tag
- `/blog` switches from static to SSR (`prerender = false`) to read the query param — same pattern as `/now`

## Test plan
- [ ] Visit `/blog/` — tag cloud appears between section nav and post list with varying sizes
- [ ] Click a tag (e.g., "tech") — page filters to matching posts, tag highlights as active, "clear" link appears
- [ ] Click "clear" — returns to full unfiltered post list
- [ ] Click a tag on an individual post page — navigates to `/blog/?tag=<tag>` with filtered results
- [ ] Verify no visual regressions on existing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)