### PR TITLE
fix: tag cloud follow-ups — shared constant, nav state, empty state

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from './BaseLayout.astro';
+import { metaTags } from '../lib/metaTags';
 
 interface Props {
   title: string;
@@ -35,7 +36,7 @@ const back = backLinks[collection];
       <h1>{title}</h1>
       <div class="post-meta">
         <time datetime={date.toISOString()}>{dateStr}</time>
-        {tags.filter(t => !['blog', 'ouatrevisit', 'elections'].includes(t)).map(tag => (
+        {tags.filter(t => !(metaTags as readonly string[]).includes(t)).map(tag => (
           <a href={`/blog/?tag=${encodeURIComponent(tag)}`} class="tag">{tag}</a>
         ))}
       </div>

--- a/src/lib/metaTags.ts
+++ b/src/lib/metaTags.ts
@@ -1,0 +1,2 @@
+/** Collection-level tags excluded from display and the tag cloud. */
+export const metaTags = ["blog", "ouatrevisit", "elections"] as const;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,11 +1,10 @@
 ---
 import { getCollection } from 'astro:content';
 import { slugFromId } from '../../lib/slugFromId';
+import { metaTags } from '../../lib/metaTags';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 
 export const prerender = false;
-
-const metaTags = ['blog', 'ouatrevisit', 'elections'];
 
 const now = new Date();
 const allPosts = (await getCollection('blog'))
@@ -44,7 +43,7 @@ const posts = activeTag
   <h1>Blog</h1>
 
   <nav class="section-nav">
-    <a href="/blog/" class="active">All</a>
+    <a href="/blog/" class:list={[{ active: !activeTag }]}>All</a>
     <a href="/blog/ouatrevisit/">Once Upon a Time Revisit</a>
     <a href="/blog/elections/">Elections</a>
   </nav>
@@ -63,6 +62,10 @@ const posts = activeTag
       Showing posts tagged <strong>{activeTag}</strong>
       <a href="/blog/" class="clear-filter">clear</a>
     </div>
+  )}
+
+  {activeTag && posts.length === 0 && (
+    <p class="empty-state">No posts tagged <strong>{activeTag}</strong>.</p>
   )}
 
   <ul class="post-list">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -15,7 +15,7 @@ const allPosts = (await getCollection('blog'))
 const tagCounts = new Map<string, number>();
 for (const post of allPosts) {
   for (const tag of post.data.tags ?? []) {
-    if (!metaTags.includes(tag)) {
+    if (!(metaTags as readonly string[]).includes(tag)) {
       tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
     }
   }
@@ -79,7 +79,7 @@ const posts = activeTag
               {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
             </time>
             {(post.data.tags ?? [])
-              .filter(t => !metaTags.includes(t))
+              .filter(t => !(metaTags as readonly string[]).includes(t))
               .map(tag => (
                 <a href={`/blog/?tag=${encodeURIComponent(tag)}`} class="tag">{tag}</a>
               ))

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -282,6 +282,11 @@ a.tag.active {
   color: var(--color-accent);
 }
 
+.empty-state {
+  color: var(--color-muted);
+  font-style: italic;
+}
+
 /* Components — Section Nav
    ---------------------------------------------------------- */
 .section-nav {


### PR DESCRIPTION
## Summary
- Extract `metaTags` array to shared `src/lib/metaTags.ts` constant, imported by both blog index and PostLayout
- Fix "All" nav link to only highlight when no tag filter is active (was always active)
- Add empty-state message when a tag filter matches zero posts

Closes #44, closes #45, closes #46.

## Test plan
- [ ] Visit `/blog/` — "All" nav link is highlighted
- [ ] Click a tag — "All" loses highlight, filtered results show
- [ ] Visit `/blog/?tag=nonexistent` — "No posts tagged" message appears
- [ ] Click tag on individual post — navigates to filtered blog index correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)