### PR TITLE
feat(ci): install ralph-burndown monthly triage workflow

### DIFF
--- a/.github/workflows/night-shift.yml
+++ b/.github/workflows/night-shift.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: smartwatermelon/ralph-burndown
+          ref: v2.2.0
           path: ralph-burndown
 
       - name: Install uv
@@ -81,6 +82,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: smartwatermelon/ralph-burndown
+          ref: v2.2.0
           path: ralph-burndown
 
       - name: Install uv

--- a/.github/workflows/ralph-triage.yml
+++ b/.github/workflows/ralph-triage.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: smartwatermelon/ralph-burndown
+          ref: v2.2.0
           path: ralph-burndown
 
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/ralph-triage.yml
+++ b/.github/workflows/ralph-triage.yml
@@ -1,0 +1,28 @@
+name: Ralph Burndown Triage
+
+on:
+  schedule:
+    - cron: '0 9 1 * *'  # 1st of every month at 9am UTC
+  workflow_dispatch:
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: smartwatermelon/ralph-burndown
+          path: ralph-burndown
+
+      - uses: astral-sh/setup-uv@v5
+      - run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run triage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        working-directory: ralph-burndown
+        run: uv run ralph-burndown triage --config configs/projectinsomnia.yml


### PR DESCRIPTION
## Summary
Install `.github/workflows/ralph-triage.yml` — monthly triage via ralph-burndown. First automated triage for this repo.

Runs on schedule (`0 9 1 * *`) and `workflow_dispatch`. Checks out `smartwatermelon/ralph-burndown`, runs `uv run ralph-burndown triage --config configs/projectinsomnia.yml`, and files a triage-report issue here.

Matches the pattern used by financial-agent, kebab-tax-netlify, night-owl-studio.

## Test plan
- [ ] After merge: `gh workflow run ralph-triage.yml` and confirm success
- [ ] Triage-report issue created with recommended bucketing
- [ ] Next scheduled fire 2026-05-01 09:00 UTC succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)