### PR TITLE
docs(about): correct day job from government tech to SRE

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -16,8 +16,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </p>
 
   <p>
-    By day I work in government technology. By night I build apps and automations
-    under <a href="https://nightowlstudio.us" target="_blank" rel="noopener noreferrer">Night Owl Studio, LLC</a>.
+    By day I'm a Site Reliability Engineer who specializes in making systems talk
+    to each other in new, exciting, and probably warranty-violating ways. By night
+    I build apps and automations under
+    <a href="https://nightowlstudio.us" target="_blank" rel="noopener noreferrer">Night Owl Studio, LLC</a>.
   </p>
 
   <h2>Find me</h2>


### PR DESCRIPTION
## Summary
- Replace the outdated "I work in government technology" line on the About page with a description of Andrew's actual role (Site Reliability Engineer) in his own voice.

## Test plan
- [ ] Visual check of Netlify deploy preview — About page renders the new two-sentence bio with the Night Owl Studio link intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)