### PR TITLE
docs(blog): convert keychain-ssh postscript to first-person voice

### DIFF
--- a/src/content/blog/2026-04-24-unlocking-login-keychain-over-ssh-headless-mac.md
+++ b/src/content/blog/2026-04-24-unlocking-login-keychain-over-ssh-headless-mac.md
@@ -228,7 +228,7 @@ The master ssh connection persists for the session duration plus sixty seconds a
 
 ## Postscript: The Preboot Trap
 
-After shipping the wrapper described above, a new failure mode surfaced — one we'd never tested for. We didn't try "ssh into a freshly-rebooted Mac mini" while developing this, and the preboot SSH phase that lives in that window had been there the whole time.
+After shipping the wrapper described above, a new failure mode surfaced — one I'd never tested for. I never tried "ssh into a freshly-rebooted Mac mini" while developing this, and the preboot SSH phase that lives in that window had been there the whole time.
 
 ### The Trigger
 
@@ -242,14 +242,14 @@ Apple's design here is also intentional and correct. The wrapper just didn't kno
 
 ### What Went Wrong
 
-The keychain-unlock dance opens an auxiliary `ssh -fNM` master before the user's interactive session, then pipes `unlock-keychain` over that master via `security -i`. Both steps assume the master will live long enough for the user's session to multiplex over it.
+The keychain-unlock dance opens an auxiliary `ssh -fNM` master before my interactive session, then pipes `unlock-keychain` over that master via `security -i`. Both steps assume the master will live long enough for my session to multiplex over it.
 
 In the FileVault preboot phase, neither assumption holds:
 
-1. The auxiliary master attempts key auth, falls back to password, and **prompts the user on `/dev/tty`** for the FileVault password. The user wasn't asking to interact with this connection — it was supposed to be invisible plumbing.
-2. Even if the user types the password, the preboot `sshd` unlocks the volume and then immediately disconnects. The "master" is a corpse before the user's real session can attach to it.
+1. The auxiliary master attempts key auth, falls back to password, and **prompts me on `/dev/tty`** for the FileVault password. I wasn't asking to interact with this connection — it was supposed to be invisible plumbing.
+2. Even if I type the password, the preboot `sshd` unlocks the volume and then immediately disconnects. The "master" is a corpse before my real session can attach to it.
 
-The user's experience was a confusing double-prompt: first for an SSH connection they didn't ask to authenticate, then a `^C` and a stderr warning, then the actual session prompt they wanted in the first place.
+What I saw was a confusing double-prompt: first an SSH connection I didn't ask to authenticate, then a `^C` and a stderr warning, then the actual session prompt I wanted in the first place.
 
 ### The Fix
 
@@ -262,13 +262,13 @@ ssh -fNM \
   "${host}"
 ```
 
-`BatchMode=yes` refuses every interactive auth method — passwords, keyboard-interactive, host-key confirmation, all of it. In the preboot phase, where only password auth is offered, the master fails fast with no `/dev/tty` access. The wrapper logs a warning, cleans up its socket, and falls through to a plain `exec ssh "$@"` — which inherits no flags and lets the user's real session prompt for the FileVault password as macOS intends.
+`BatchMode=yes` refuses every interactive auth method — passwords, keyboard-interactive, host-key confirmation, all of it. In the preboot phase, where only password auth is offered, the master fails fast with no `/dev/tty` access. The wrapper logs a warning, cleans up its socket, and falls through to a plain `exec ssh "$@"` — which inherits no flags and lets my real session prompt for the FileVault password as macOS intends.
 
-`ConnectTimeout=10` caps the master at ten seconds so partially-booted hosts (TCP up, `sshd` hung on banner) don't stall the wrapper indefinitely. The user's interactive session has no such cap; it gets the kernel's default TCP timeout, which is the right behavior for a session the user is actively waiting on.
+`ConnectTimeout=10` caps the master at ten seconds so partially-booted hosts (TCP up, `sshd` hung on banner) don't stall the wrapper indefinitely. My interactive session has no such cap; it gets the kernel's default TCP timeout, which is the right behavior for a session I'm actively waiting on.
 
 ### A New Scope Limitation
 
-`BatchMode=yes` is the *correct* gate for the preboot case, but it gates more than the preboot case. Any host that legitimately accepts only password or keyboard-interactive auth — a freshly-provisioned box, a server with PAM 2FA, a Yubico challenge — now silently fails the master-open step. The keychain-unlock dance is skipped on those hosts. The fall-through is harmless (the user's session still works), but the convenience is gone until key authentication is in place.
+`BatchMode=yes` is the *correct* gate for the preboot case, but it gates more than the preboot case. Any host that legitimately accepts only password or keyboard-interactive auth — a freshly-provisioned box, a server with PAM 2FA, a Yubico challenge — now silently fails the master-open step. The keychain-unlock dance is skipped on those hosts. The fall-through is harmless (my session still works), but the convenience is gone until key authentication is in place.
 
 This is acceptable for the original use case (a personal Mac mini where keys are deployed once and forever), but worth flagging for anyone porting the design. A more general implementation might add a per-host opt-out — `# op-keychain-allow-password: yes` — to permit the master to take a password when the operator explicitly accepts the UX cost. For now, the simpler gate keeps the failure mode legible: if you don't have key auth on the host, the wrapper will not surprise you with a prompt.
 
@@ -276,14 +276,14 @@ This is acceptable for the original use case (a personal Mac mini where keys are
 
 The invariants above all still hold. One can be added:
 
-- The wrapper never holds open an interactive prompt on `/dev/tty` for a connection the user did not initiate.
+- The wrapper never holds open an interactive prompt on `/dev/tty` for a connection I did not initiate.
 
 That invariant was implicit before — accidentally satisfied by the assumption that key authentication would always succeed. The preboot case made it explicit.
 
 ### Recap
 
 - macOS Tahoe added a preboot SSH phase that accepts only passwords and disconnects after FileVault unlock.
-- The wrapper's auxiliary master collided with this state by prompting for a password the user didn't want to enter and then dying anyway.
+- The wrapper's auxiliary master collided with this state by prompting for a password I didn't want to enter and then dying anyway.
 - `BatchMode=yes` + `ConnectTimeout=10` on the master invocation pushes the failure to a fast, silent, no-`tty` exit, and the wrapper falls through to the plain SSH path that handles the preboot unlock correctly.
 - The tradeoff — losing the convenience on password-only hosts — is acceptable for the design's intended scope.
 


### PR DESCRIPTION
## Summary

Follow-up to #59. Converts third-person ("the user", "we") references in the Preboot Trap postscript to first-person ("I", "my") to match the post's overall voice. The original post is written in first-person singular and describes the author's own setup; the postscript drifted to a more abstract voice and read as if multiple people were involved.

Affected lines: ~10 substitutions inside the postscript section. No structural changes; "the operator" reference in the "more general implementation" hypothetical is intentionally kept since it refers to a hypothetical porter, not the author.

## Test plan

- [x] markdownlint passes
- [x] `npx astro build` clean
- [ ] Netlify deploy preview reads in consistent first-person voice
- [ ] No remaining "the user" / "we" references inside the postscript

🤖 Generated with [Claude Code](https://claude.com/claude-code)