### PR TITLE
chore: bump claude-blocking-review @v2.0.2 → @v3

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   claude-review:
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v2.0.2
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:


### PR DESCRIPTION
## Summary

Bumps the pinned version of `smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml` from `@v2.0.2` to `@v3` (released today via [github-workflows#62](https://github.com/smartwatermelon/github-workflows/pull/62)).

## What v3 changed

- **Drops the `--max-turns` cap on the Claude review agent.** Reviews are now bounded only by the wall-clock `timeout-minutes` (the hard safety net), the prompt's scope discipline, and the OAuth subscription quota. The "exceeded turn limit" failure mode that recently force-killed reviews on small/medium diffs is gone.
- **Removes the `max_turns` input parameter.** This caller workflow does not pass it, so no other change is required.
- **Re-bases timeout estimation** on diff size directly: `10 + lines/100` minutes (floor 10, cap 30).
- **Tightens the prompt** with explicit self-bounding (3-file ceiling per hypothesis) since it's now the soft constraint where the turn cap used to be the hard one.

## Test plan

- [ ] CI on this PR exercises the bumped workflow on a workflow-only diff — the workflow's PRIORITY SKIP path should fire (claude-code-action refuses to review PRs that modify workflows). Status check should pass quickly.
- [ ] Next non-workflow PR after merge gets the real v3 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)