### PR TITLE
feat: pinned posts on / and /blog/

### DIFF
--- a/docs/plans/2026-04-28-pinned-posts-design.md
+++ b/docs/plans/2026-04-28-pinned-posts-design.md
@@ -1,0 +1,218 @@
+# Pinned Posts — Homepage and Blog Index Design
+
+**Date**: 2026-04-28
+**Status**: Approved, ready for implementation
+
+---
+
+## Goal
+
+Let Andrew flag specific blog posts as "pinned" via a frontmatter tag. Pinned
+posts appear in a separate `## Pinned` block above the chronological list on
+both `/` (homepage) and `/blog/` (blog index), so the most important posts are
+immediately visible to visitors regardless of publish date.
+
+---
+
+## Data Model
+
+Pinning is a frontmatter edit — add `pinned` to the existing `tags` array:
+
+```yaml
+---
+title: My Important Post
+date: 2025-09-12
+tags: [pinned, engineering]
+---
+```
+
+`pinned` is added to `metaTags` in `src/lib/metaTags.ts`, so it is excluded
+from the tag cloud and from per-post tag chips on `/blog/`. A new helper
+`isPinned(post)` lives next to `isMetaTag` for clarity at call sites.
+
+```ts
+// src/lib/metaTags.ts
+export const metaTags = ["blog", "ouatrevisit", "elections", "pinned"] as const;
+export const PINNED_TAG = "pinned";
+export function isPinned(post: { data: { tags?: string[] } }): boolean {
+  return (post.data.tags ?? []).includes(PINNED_TAG);
+}
+```
+
+### Why tags over a discrete schema field
+
+Alternative would be `pinned: z.boolean().default(false)` in
+`content.config.ts`. That gives cleaner separation of editorial flag from
+topic tags but requires a schema change and gives no real ergonomic win.
+Adding `pinned` to the tag array is one keystroke and the existing meta-tag
+infrastructure already handles exclusion. Keeping curation in the tag array
+also means future flags (e.g. `evergreen`, `series:foo`) plug in without
+further schema churn.
+
+### Scope
+
+Blog collection only. The `ouatrevisit` and `elections` collections are
+siloed and have their own indexes; pinning there is not requested.
+
+---
+
+## Homepage (`src/pages/index.astro`)
+
+Current behavior: filter to non-draft published posts, sort newest-first,
+slice to 5. The change splits that into two arrays.
+
+```ts
+const all = (await getCollection('blog'))
+  .filter(p => !p.data.draft && p.data.date <= now)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+const pinned = all.filter(isPinned);
+const recent = all.filter(p => !isPinned(p)).slice(0, 5);
+```
+
+Two `<section>` blocks render, with the Pinned section omitted entirely when
+there are zero pinned posts:
+
+```astro
+{pinned.length > 0 && (
+  <section class="pinned-posts">
+    <h2>Pinned</h2>
+    <ul class="post-list">
+      {pinned.map(post => /* same item markup as Recent */)}
+    </ul>
+  </section>
+)}
+
+<section class="recent-posts">
+  <h2>Recent Posts</h2>
+  <ul class="post-list">
+    {recent.map(post => /* unchanged */)}
+  </ul>
+  <p><a href="/blog/">All posts →</a></p>
+</section>
+```
+
+### Behavior on homepage
+
+- Zero pinned posts → page looks identical to today; no empty heading.
+- Recent Posts excludes anything pinned, so a freshly-published post that is
+  also pinned shows only in Pinned (no duplication).
+- The `slice(0, 5)` budget applies only to non-pinned, so total visible =
+  pinnedCount + 5.
+- "All posts →" link stays under Recent Posts only.
+
+---
+
+## Blog Index (`src/pages/blog/index.astro`)
+
+Adds the same Pinned/Recent split, but only on the unfiltered view. When a
+tag filter is active (`?tag=anything`), the Pinned block is hidden and the
+list shows all matching posts in chronological order.
+
+```ts
+const allPosts = (await getCollection('blog'))
+  .filter(p => !p.data.draft && p.data.date <= now)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+const activeTag = Astro.url.searchParams.get('tag');
+const filtered = activeTag
+  ? allPosts.filter(p => (p.data.tags ?? []).includes(activeTag))
+  : allPosts;
+
+const showPinnedSection = !activeTag;
+const pinned = showPinnedSection ? allPosts.filter(isPinned) : [];
+const remaining = showPinnedSection
+  ? filtered.filter(p => !isPinned(p))
+  : filtered;
+```
+
+Markup adds a Pinned block above the existing list, conditional on
+`showPinnedSection && pinned.length > 0`.
+
+### Behavior on /blog/
+
+- Tag cloud is unchanged. `pinned` is a meta tag, so it never appears.
+- Filter view is pure: `?tag=X` hides the Pinned block and includes any
+  pinned posts that match the filter inline with the chronological list.
+- Per-post tag chips: `pinned` is already filtered out by the existing
+  `isMetaTag` check on the chip render, so no change needed there.
+- The `tag-filter-status` "Showing posts tagged X" line and the "no posts"
+  empty-state stay scoped to `remaining`.
+- No `<h2>Recent Posts</h2>` is added on `/blog/`. The existing page has no
+  heading on the list; adding one would feel awkward when there is no Pinned
+  block (zero pins, or filter active). Keeping the existing list
+  heading-less means the page degrades cleanly.
+
+---
+
+## Styling (`src/styles/global.css`)
+
+The `.post-list` styling already exists and works for both blocks. Add only:
+
+```css
+.pinned-posts { margin-bottom: 2.5rem; }
+.pinned-posts h2 { margin-top: 0; }
+```
+
+No special "pinned" badge or icon on individual items. The section heading
+is the signal. A subtle pin glyph on each title can be added later as a
+one-line change if desired.
+
+---
+
+## Out of Scope
+
+- **RSS**: stays purely chronological. RSS readers handle ordering
+  themselves, and republishing a re-pinned post would confuse readers.
+- **Sitemap**: no change.
+- **Siloed collections** (`ouatrevisit`, `elections`): no pinning.
+- **Schema field**: no `pinned: boolean` added to the content schema.
+- **Hard cap on pinned count**: not enforced. If the block grows unwieldy
+  that is a signal to unpin older posts manually.
+
+---
+
+## Editorial Loop
+
+1. Edit the post's frontmatter, add or remove `pinned` from `tags`.
+2. Commit on a branch, push, merge.
+3. Netlify rebuilds; pin appears or disappears.
+
+No admin UI, no separate config file, no rebuild step beyond the normal
+deploy.
+
+---
+
+## Edge Cases
+
+- Zero pinned posts → Pinned section omitted, layouts identical to today.
+- All pinned posts are drafts or future-dated → filtered out by the existing
+  `!draft && date <= now` gate before the pin split, so the section will
+  not show stale entries.
+- Pinned post deleted → tag goes with it; section recalculates on next build.
+- Future-dated pinned post → does not appear until its date passes,
+  consistent with current behavior.
+
+---
+
+## Files Changed
+
+1. `src/lib/metaTags.ts` — extend `metaTags`, export `PINNED_TAG` and
+   `isPinned()`.
+2. `src/pages/index.astro` — split posts, render Pinned section
+   conditionally.
+3. `src/pages/blog/index.astro` — same split, gated on `!activeTag`.
+4. `src/styles/global.css` — two CSS rules.
+
+No changes to `content.config.ts`, RSS, sitemap, individual post layout, or
+the siloed collections.
+
+---
+
+## Local Verification
+
+- `pnpm build` — verify no schema or render errors.
+- `pnpm dev`, pin one existing post, check `/` and `/blog/` show the Pinned
+  block above the chronological list.
+- Visit `/blog/?tag=<existing-tag>` — confirm Pinned block disappears.
+- Unpin, confirm both pages return to baseline (no Pinned heading).

--- a/docs/plans/2026-04-28-pinned-posts-impl.md
+++ b/docs/plans/2026-04-28-pinned-posts-impl.md
@@ -1,0 +1,398 @@
+# Pinned Posts Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to
+> implement this plan task-by-task.
+
+**Goal:** Let Andrew flag specific blog posts with a `pinned` tag so they
+render in a dedicated `## Pinned` section above the chronological list on
+both `/` (homepage) and `/blog/`.
+
+**Architecture:** Reuses the existing `metaTags` exclusion mechanism in
+`src/lib/metaTags.ts`. No content-schema change. Two page components are
+modified to split the post array into pinned/non-pinned and render two
+sections. CSS adds two rules.
+
+**Tech Stack:** Astro 5, TypeScript, plain CSS. Build via `pnpm build`,
+type-check via `npx astro check`.
+
+**Branch:** `claude/feat-pinned-posts-20260428` (already created).
+
+**Design doc:** `docs/plans/2026-04-28-pinned-posts-design.md`.
+
+---
+
+## Pre-flight
+
+Confirm working directory and branch:
+
+```bash
+pwd                                  # /Users/andrewrich/Developer/netlify/projectinsomnia
+git branch --show-current            # claude/feat-pinned-posts-20260428
+git status --short                   # clean
+```
+
+---
+
+## Task 1: Extend `metaTags.ts` with `isPinned()`
+
+**Files:**
+
+- Modify: `src/lib/metaTags.ts`
+
+### Step 1: Update the file
+
+Replace the contents of `src/lib/metaTags.ts` with:
+
+```ts
+/** Collection-level tags excluded from display and the tag cloud. */
+export const metaTags = ["blog", "ouatrevisit", "elections", "pinned"] as const;
+
+/** The tag literal that flags a post as pinned to the top of post lists. */
+export const PINNED_TAG = "pinned";
+
+/** Returns true if the given tag is a collection-level meta tag. */
+export function isMetaTag(t: string): boolean {
+  return (metaTags as readonly string[]).includes(t);
+}
+
+/** Returns true if the post is pinned (carries the `pinned` tag). */
+export function isPinned(post: { data: { tags?: string[] } }): boolean {
+  return (post.data.tags ?? []).includes(PINNED_TAG);
+}
+```
+
+### Step 2: Type-check
+
+Run: `npx astro check 2>&1 | tail -10`
+Expected: `0 errors, 0 warnings, 0 hints` (or similar). Any new error means
+the export shape regressed an existing import.
+
+### Step 3: Commit
+
+```bash
+git add src/lib/metaTags.ts
+git commit -m "feat(metaTags): add PINNED_TAG and isPinned() helper
+
+Adds 'pinned' to the meta-tag exclusion list (so it stays out of the
+tag cloud and per-post chips) and exports a typed helper for use by
+the homepage and blog index."
+```
+
+---
+
+## Task 2: Homepage — split into Pinned + Recent sections
+
+**Files:**
+
+- Modify: `src/pages/index.astro`
+
+### Step 1: Update the frontmatter (lines 1-11)
+
+Replace the existing import block and post-loading logic with:
+
+```ts
+---
+import { getCollection } from 'astro:content';
+import { slugFromId } from '../lib/slugFromId';
+import { isPinned } from '../lib/metaTags';
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const now = new Date();
+const all = (await getCollection('blog'))
+  .filter(p => !p.data.draft && p.data.date <= now)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+const pinned = all.filter(isPinned);
+const recent = all.filter(p => !isPinned(p)).slice(0, 5);
+---
+```
+
+### Step 2: Update the body
+
+Replace the `<section class="recent-posts">…</section>` block with:
+
+```astro
+{pinned.length > 0 && (
+  <section class="pinned-posts">
+    <h2>Pinned</h2>
+    <ul class="post-list">
+      {pinned.map(post => {
+        const slug = slugFromId(post.id);
+        return (
+          <li>
+            <a href={`/blog/${slug}/`}>{post.data.title}</a>
+            <div class="post-meta">
+              <time datetime={post.data.date.toISOString()}>
+                {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
+              </time>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  </section>
+)}
+
+<section class="recent-posts">
+  <h2>Recent Posts</h2>
+  <ul class="post-list">
+    {recent.map(post => {
+      const slug = slugFromId(post.id);
+      return (
+        <li>
+          <a href={`/blog/${slug}/`}>{post.data.title}</a>
+          <div class="post-meta">
+            <time datetime={post.data.date.toISOString()}>
+              {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
+            </time>
+          </div>
+        </li>
+      );
+    })}
+  </ul>
+  <p><a href="/blog/">All posts →</a></p>
+</section>
+```
+
+The `posts.map(...)` body is duplicated by design — six lines, not worth
+extracting a component yet (YAGNI).
+
+### Step 3: Build
+
+Run: `pnpm build 2>&1 | tail -20`
+Expected: build completes, ends with `Complete!` or similar success line.
+No type errors, no missing-import warnings.
+
+### Step 4: Commit
+
+```bash
+git add src/pages/index.astro
+git commit -m "feat(home): split posts into Pinned + Recent sections
+
+When any blog post carries the 'pinned' tag, the homepage shows a
+'Pinned' section above the existing 'Recent Posts' list. Recent
+Posts excludes pinned items to avoid duplication. With zero pinned
+posts the page renders identically to before."
+```
+
+---
+
+## Task 3: Blog index — split with filter-aware gating
+
+**Files:**
+
+- Modify: `src/pages/blog/index.astro`
+
+### Step 1: Update the frontmatter
+
+Replace the existing post-loading and filter logic. The new version:
+
+- adds `isPinned` to the `metaTags` import
+- computes `showPinnedSection`, `pinned`, and `remaining`
+
+The section near `// Filter by active tag` becomes:
+
+```ts
+import { isMetaTag, isPinned } from '../../lib/metaTags';
+```
+
+```ts
+// Filter by active tag
+const activeTag = Astro.url.searchParams.get('tag');
+const filtered = activeTag
+  ? allPosts.filter(p => (p.data.tags ?? []).includes(activeTag))
+  : allPosts;
+
+const showPinnedSection = !activeTag;
+const pinned = showPinnedSection ? allPosts.filter(isPinned) : [];
+const remaining = showPinnedSection
+  ? filtered.filter(p => !isPinned(p))
+  : filtered;
+```
+
+### Step 2: Update the body to render Pinned, then the existing list
+
+Insert this block immediately above the existing `{activeTag && (...)}`
+filter-status block (the one that starts with `{activeTag && (`):
+
+```astro
+{showPinnedSection && pinned.length > 0 && (
+  <section class="pinned-posts">
+    <h2>Pinned</h2>
+    <ul class="post-list">
+      {pinned.map(post => {
+        const slug = slugFromId(post.id);
+        return (
+          <li>
+            <a href={`/blog/${slug}/`}>{post.data.title}</a>
+            <div class="post-meta">
+              <time datetime={post.data.date.toISOString()}>
+                {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
+              </time>
+              {(post.data.tags ?? [])
+                .filter(t => !isMetaTag(t))
+                .map(tag => (
+                  <a href={`/blog/?tag=${encodeURIComponent(tag)}`} class="tag">{tag}</a>
+                ))
+              }
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  </section>
+)}
+```
+
+Then change the existing list iteration from `posts.map` to `remaining.map`
+on the chronological `<ul class="post-list">` block.
+
+Also change `posts.length === 0` in the empty-state check to
+`remaining.length === 0`.
+
+The `posts` variable defined under `// Filter by active tag` is removed —
+`remaining` replaces it.
+
+### Step 3: Build
+
+Run: `pnpm build 2>&1 | tail -20`
+Expected: build completes successfully. No `posts is not defined` errors.
+
+### Step 4: Commit
+
+```bash
+git add src/pages/blog/index.astro
+git commit -m "feat(blog): pinned posts surface above chronological list
+
+Pinned section appears above the chronological list on the
+unfiltered /blog/ view. When a tag filter is active (?tag=X), the
+Pinned section is hidden and pinned posts that match the filter
+appear inline with the rest. Tag chips on pinned items still hide
+the meta-only 'pinned' tag via the existing isMetaTag check."
+```
+
+---
+
+## Task 4: CSS — Pinned section spacing
+
+**Files:**
+
+- Modify: `src/styles/global.css`
+
+### Step 1: Add two rules
+
+Append (or place near other section-level rules — find where
+`.recent-posts` or similar rules live and insert nearby for cohesion):
+
+```css
+.pinned-posts { margin-bottom: 2.5rem; }
+.pinned-posts h2 { margin-top: 0; }
+```
+
+### Step 2: Build
+
+Run: `pnpm build 2>&1 | tail -10`
+Expected: success.
+
+### Step 3: Commit
+
+```bash
+git add src/styles/global.css
+git commit -m "style: spacing for .pinned-posts section"
+```
+
+---
+
+## Task 5: Manual verification (do not commit the test pin)
+
+### Step 1: Pick a sample post and pin it temporarily
+
+```bash
+ls src/content/blog/ | head
+```
+
+Pick any post, e.g. `2026-03-XX-some-post.md`. Open its frontmatter and add
+`pinned` to the tags array. Save — but **do not commit**. This is a
+verification step only.
+
+### Step 2: Start dev server
+
+Run: `pnpm dev`
+Expected: server starts on localhost:4321 (or 3000 — check output).
+
+### Step 3: Verify each surface
+
+In a browser (or via curl) check:
+
+- `/` — Pinned section appears above Recent Posts. The pinned post is in
+  the Pinned section, not in Recent Posts. Recent Posts shows 5 items.
+- `/blog/` — Pinned section appears above the chronological list. Pinned
+  post is not duplicated below.
+- `/blog/?tag=<some-existing-tag>` — Pinned section is gone. List shows
+  matching posts in chronological order.
+- Tag cloud on `/blog/` — `pinned` does not appear.
+- Per-post tag chips — `pinned` does not appear on the pinned post's chip
+  list.
+
+### Step 4: Unpin the test post
+
+Remove `pinned` from the test post's tags. Save.
+
+### Step 5: Verify baseline restored
+
+Reload `/` and `/blog/` — no Pinned section, layout identical to before
+the change.
+
+### Step 6: Confirm git state is clean
+
+```bash
+git status --short
+```
+
+Expected: clean. If the test post still shows as modified, revert it:
+
+```bash
+git checkout -- src/content/blog/<test-post>.md
+```
+
+### Step 7: Stop the dev server (Ctrl-C)
+
+---
+
+## Wrap-up
+
+Run the full local review gate before considering the work complete:
+
+```bash
+pnpm build 2>&1 | tail -10
+git log --oneline main..HEAD
+```
+
+Expected: 4 commits beyond main (metaTags, homepage, blog index, CSS).
+
+The pre-commit hook will have run `code-reviewer` and `adversarial-reviewer`
+on each commit; verify the latest review log:
+
+```bash
+head -6 $(git rev-parse --git-dir)/last-review-result.log
+```
+
+If clean, the branch is ready to push. **Do not push or open a PR
+automatically — wait for explicit approval per Protocol 6.**
+
+---
+
+## Rollback
+
+If anything goes sideways mid-implementation:
+
+```bash
+git reset --hard <commit-before-task-N>
+```
+
+Or to abandon the whole branch:
+
+```bash
+git switch main
+git branch -D claude/feat-pinned-posts-20260428
+```

--- a/src/content/blog/2026-04-01-solo-building-observability-platform.md
+++ b/src/content/blog/2026-04-01-solo-building-observability-platform.md
@@ -2,7 +2,7 @@
 title: "I Solo-Built a Production Observability Platform. Then I Got Laid Off by Email."
 date: 2026-04-01
 description: "How one sentence of requirements became a full-stack data platform — Python, FastAPI, Streamlit, SQLite, Kubernetes — built solo over 5 months at Oracle Health. Then 30,000 of us got the same email."
-tags: ["python", "kubernetes", "sqlite", "fastapi", "streamlit", "oracle"]
+tags: ["pinned", "python", "kubernetes", "sqlite", "fastapi", "streamlit", "oracle"]
 ---
 
 Last week I was part of Oracle's widely-reported reduction of approximately 30,000 positions. I got the news the same way everyone else did: by email. This is a project I built during my time there — a [Principal SRE](https://www.linkedin.com/in/andrewrich/) working solo on something that started with a single sentence and grew into a production platform processing over 11 million records.

--- a/src/content/blog/2026-04-24-unlocking-login-keychain-over-ssh-headless-mac.md
+++ b/src/content/blog/2026-04-24-unlocking-login-keychain-over-ssh-headless-mac.md
@@ -2,7 +2,7 @@
 title: "Unlocking the Login Keychain Over SSH on a Headless Mac"
 date: 2026-04-24
 description: "macOS locks the login keychain when there's no GUI login, which quietly breaks Claude Code, git credential helpers, and anything that calls SecKeychainFindGenericPassword. The fix: 1Password on the client, ssh connection multiplexing, and `security -i` on the remote — no password in argv, on disk, or in env on either side."
-tags: ["tech", "security", "macos", "ssh", "1password"]
+tags: ["pinned", "tech", "security", "macos", "ssh", "1password"]
 ---
 
 ## The Broken Thing

--- a/src/lib/metaTags.ts
+++ b/src/lib/metaTags.ts
@@ -1,7 +1,15 @@
 /** Collection-level tags excluded from display and the tag cloud. */
-export const metaTags = ["blog", "ouatrevisit", "elections"] as const;
+export const metaTags = ["blog", "ouatrevisit", "elections", "pinned"] as const;
+
+/** The tag literal that flags a post as pinned to the top of post lists. */
+export const PINNED_TAG = "pinned";
 
 /** Returns true if the given tag is a collection-level meta tag. */
 export function isMetaTag(t: string): boolean {
   return (metaTags as readonly string[]).includes(t);
+}
+
+/** Returns true if the post is pinned (carries the `pinned` tag). */
+export function isPinned(post: { data: { tags?: string[] } }): boolean {
+  return (post.data.tags ?? []).includes(PINNED_TAG);
 }

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -64,8 +64,7 @@ const remaining = showPinnedSection
   </div>
 
   {showPinnedSection && pinned.length > 0 && (
-    <section class="pinned-posts">
-      <h2>Pinned</h2>
+    <section class="pinned-posts" aria-label="Pinned posts">
       <ul class="post-list">
         {pinned.map(post => {
           const slug = slugFromId(post.id);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import { slugFromId } from '../../lib/slugFromId';
-import { isMetaTag } from '../../lib/metaTags';
+import { isMetaTag, isPinned } from '../../lib/metaTags';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 
 export const prerender = false;
@@ -34,9 +34,15 @@ function tagSize(count: number): string {
 
 // Filter by active tag
 const activeTag = Astro.url.searchParams.get('tag');
-const posts = activeTag
+const filtered = activeTag
   ? allPosts.filter(p => (p.data.tags ?? []).includes(activeTag))
   : allPosts;
+
+const showPinnedSection = !activeTag;
+const pinned = showPinnedSection ? allPosts.filter(isPinned) : [];
+const remaining = showPinnedSection
+  ? filtered.filter(p => !isPinned(p))
+  : filtered;
 ---
 
 <BaseLayout title={activeTag ? `Blog — #${activeTag}` : 'Blog'}>
@@ -57,6 +63,33 @@ const posts = activeTag
     ))}
   </div>
 
+  {showPinnedSection && pinned.length > 0 && (
+    <section class="pinned-posts">
+      <h2>Pinned</h2>
+      <ul class="post-list">
+        {pinned.map(post => {
+          const slug = slugFromId(post.id);
+          return (
+            <li>
+              <a href={`/blog/${slug}/`}>{post.data.title}</a>
+              <div class="post-meta">
+                <time datetime={post.data.date.toISOString()}>
+                  {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
+                </time>
+                {(post.data.tags ?? [])
+                  .filter(t => !isMetaTag(t))
+                  .map(tag => (
+                    <a href={`/blog/?tag=${encodeURIComponent(tag)}`} class="tag">{tag}</a>
+                  ))
+                }
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  )}
+
   {activeTag && (
     <div class="tag-filter-status">
       Showing posts tagged <strong>{activeTag}</strong>
@@ -64,12 +97,12 @@ const posts = activeTag
     </div>
   )}
 
-  {activeTag && posts.length === 0 && (
+  {activeTag && remaining.length === 0 && (
     <p class="empty-state">No posts tagged <strong>{activeTag}</strong>.</p>
   )}
 
   <ul class="post-list">
-    {posts.map(post => {
+    {remaining.map(post => {
       const slug = slugFromId(post.id);
       return (
         <li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,13 +1,16 @@
 ---
 import { getCollection } from 'astro:content';
 import { slugFromId } from '../lib/slugFromId';
+import { isPinned } from '../lib/metaTags';
 import BaseLayout from '../layouts/BaseLayout.astro';
 
 const now = new Date();
-const posts = (await getCollection('blog'))
+const all = (await getCollection('blog'))
   .filter(p => !p.data.draft && p.data.date <= now)
-  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
-  .slice(0, 5);
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+const pinned = all.filter(isPinned);
+const recent = all.filter(p => !isPinned(p)).slice(0, 5);
 ---
 
 <BaseLayout title="Home">
@@ -20,10 +23,31 @@ const posts = (await getCollection('blog'))
     <p>Based in Spokane, WA.</p>
   </section>
 
+  {pinned.length > 0 && (
+    <section class="pinned-posts">
+      <h2>Pinned</h2>
+      <ul class="post-list">
+        {pinned.map(post => {
+          const slug = slugFromId(post.id);
+          return (
+            <li>
+              <a href={`/blog/${slug}/`}>{post.data.title}</a>
+              <div class="post-meta">
+                <time datetime={post.data.date.toISOString()}>
+                  {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
+                </time>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  )}
+
   <section class="recent-posts">
     <h2>Recent Posts</h2>
     <ul class="post-list">
-      {posts.map(post => {
+      {recent.map(post => {
         const slug = slugFromId(post.id);
         return (
           <li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -184,6 +184,15 @@ hr {
   margin: 2rem 0;
 }
 
+/* Components — Pinned Posts Section
+   ---------------------------------------------------------- */
+.pinned-posts {
+  margin-bottom: 2.5rem;
+}
+.pinned-posts h2 {
+  margin-top: 0;
+}
+
 /* Components — Post List
    ---------------------------------------------------------- */
 .post-list {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -187,10 +187,17 @@ hr {
 /* Components — Pinned Posts Section
    ---------------------------------------------------------- */
 .pinned-posts {
+  background: var(--color-surface);
+  border-radius: 4px;
+  padding: 1rem 1.25rem;
   margin-bottom: 2.5rem;
 }
 .pinned-posts h2 {
   margin-top: 0;
+}
+.pinned-posts .post-list li:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
 }
 
 /* Components — Post List


### PR DESCRIPTION
## Summary

- Adds a `pinned` frontmatter tag that surfaces selected posts in a dedicated **Pinned** section above the chronological list on `/` and `/blog/`.
- Reuses the existing `metaTags` exclusion mechanism, so `pinned` never appears in the tag cloud or as a chip on individual posts.
- Pins two posts in this PR: the observability-platform write-up and the keychain-over-SSH walkthrough.

## What changed

- `src/lib/metaTags.ts` — adds `"pinned"` to the meta-tag list, exports `PINNED_TAG` and `isPinned()`.
- `src/pages/index.astro` — splits posts into Pinned + Recent (5 most-recent non-pinned).
- `src/pages/blog/index.astro` — Pinned section shown only on the unfiltered view; tag-filter views remain pure.
- `src/styles/global.css` — two CSS rules for spacing.
- Two posts get the `pinned` tag in their frontmatter.
- Design + implementation plan committed under `docs/plans/`.

## Test plan

- [ ] CI passes
- [ ] Netlify deploy preview shows Pinned section above Recent Posts on `/`
- [ ] Pinned section appears above the chronological list on `/blog/`
- [ ] `/blog/?tag=tech` (or any tag) hides the Pinned section
- [ ] `pinned` does not appear in the tag cloud
- [ ] No `pinned` chip on the two pinned posts
- [ ] No duplicate listings between Pinned and Recent

🤖 Generated with [Claude Code](https://claude.com/claude-code)