### PR TITLE
fix(now): increase feed fetch timeout from 5s to 10s

### DIFF
--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -89,7 +89,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   function timedFetch(url: string): Promise<Response> {
     const controller = new AbortController();
-    const id = setTimeout(() => controller.abort(), 5000);
+    const id = setTimeout(() => controller.abort(), 10000);
     return fetch(url, { signal: controller.signal }).finally(() => clearTimeout(id));
   }
 


### PR DESCRIPTION
## Summary
- Bumps the client-side `timedFetch` abort timeout from 5s to 10s
- Prevents feeds from silently failing on first page load when Netlify function cold-starts combine with upstream latency

## Test plan
- [ ] Load /now on deploy preview with empty browser cache — all three feeds should populate
- [ ] Verify feeds still show "Activity feed unavailable" if the endpoint is actually down (not just slow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)