### PR TITLE
docs(blog): revise Five Races post with specifics and stronger ending

### DIFF
--- a/src/content/blog/2026-07-20-five-races.md
+++ b/src/content/blog/2026-07-20-five-races.md
@@ -1,7 +1,7 @@
 ---
 title: "Five Races"
 date: 2026-07-20
-description: "One finish, then five straight races I didn't complete. Why I'm retiring from long-course triathlon, and what a dangerous race in 2023 broke that two years and a good course couldn't fix."
+description: "One finish, then five races I didn't complete. Why I'm retiring from long-course triathlon, and how a race in 2023 shaped the two years that followed."
 tags: ["triathlon", "ironman", "mental-health", "racing"]
 ---
 
@@ -9,7 +9,7 @@ IRONMAN 70.3 Oregon in 2022 was my fourth 70.3 finish, and by then I'd already c
 
 Victoria, 2023: a bike mechanical, then I hit the run cutoff. Arizona, 2023: I DNFed on the run, in the second half, in heat I still believe should have ended the race. Washington Tri-Cities, 2024: withdrew before the start. La Quinta, 2025: withdrew before the start. Oregon, 2026: withdrew the morning of the race, before transition even opened.
 
-One finish. Two DNFs. Three withdrawals. Five races in a row I did not complete. I registered for Oregon again this year because it's a course I know and a course I'd already beaten once: a fast downriver swim, a bike that's mostly flat, a run that's flat and shaded. I told my wife before the race that I intended to retire from long-course triathlon after this one no matter what happened. Five consecutive failures doesn't argue for a sixth attempt.
+One finish. Two DNFs. Three withdrawals. Five races in a row I did not complete. I registered for Oregon again this year because it's a course I know and a course I'd already beaten once: a fast downriver swim, a bike that's mostly flat, a run that's flat and shaded. I told my wife before the race that I intended to retire from long-course triathlon after this one no matter what happened. Five consecutive races I did not complete gave me no reason to plan a sixth.
 
 The count is the least interesting part of this, though. Here's the rest of it.
 
@@ -19,9 +19,9 @@ Then COVID happened, and then long COVID happened, and it did real damage. Befor
 
 In late 2022 I had rotator cuff surgery on my right shoulder. The repair itself went fine, and my shoulder was physically ready to race by Victoria in 2023. I don't think the rest of me was.
 
-Then Arizona. Look up the weather in Tempe on October 22, 2023, specifically around Tempe Town Lake in the early afternoon. I DNFed on the run in conditions I think were genuinely dangerous, and I know I'm in the minority holding IRONMAN responsible for not adjusting or pulling the race. I still believe it.
+Then Arizona. On October 22, 2023, at nearby Phoenix Sky Harbor, it was 94°F at 12:51pm, 96°F at 2:51pm, and 98°F at 3:51pm; relative humidity fell from 17% to 12%, with almost no wind. I DNFed on the run in conditions I believe were genuinely dangerous. I know I'm in the minority in believing IRONMAN should have modified or stopped the race, but I still believe it.
 
-Arizona cost me more than a finish. It cost me two more years.
+Arizona shaped the next two years of my racing.
 
 I registered for Washington Tri-Cities 2024 at the Arizona finish line area, before I'd even left. When it came time to race, I could not get anywhere near clear of the headspace Arizona had left me in. I withdrew.
 
@@ -29,7 +29,9 @@ I registered for La Quinta 2025 after withdrawing from Tri-Cities, thinking two 
 
 This year's training cycle for Oregon overlapped with a stretch of unemployment (since resolved) and the worst mental state I've been in for decades. I'm being treated for depression and anxiety, on fluoxetine and hydroxyzine, and still working through it. In practice, "training" meant Orangetheory, Pilates, and watching my weight. Almost no bike. No swim at all.
 
-I still went into the weekend thinking I could finish. Not fast, not well, just finish. My plan was built entirely around margin: in the water by 7am against a 30-minute swim and a first bike cutoff hours away, a bike leg I planned to ride easy, a run I could walk most of and still beat cutoff with time to spare. On paper it worked. I've stood on enough start lines, twelve to fifteen triathlons including eight IRONMAN races, to know what a conservative, defensible plan looks like, and this was one.
+I still went into the weekend thinking I could finish. Not fast, not well, just finish. My plan was built entirely around margin: in the water by 7am against a 30-minute swim and a first bike cutoff hours away, a bike leg I planned to ride easy, a run I could walk most of and still beat cutoff with time to spare. On paper it worked. I've stood on thirteen triathlon start lines, including seven IRONMAN 70.3s and one full IRONMAN. I know what a conservative, defensible plan looks like, and this was one.
+
+After Victoria, I bought a new bike: an A2 Bikes SP1.1, the bike in these photos.
 
 ![My triathlon bike racked on the back of our Kia EV6, loaded up to leave home for the drive to Oregon](/images/blog/five-races-bike-on-car.jpg)
 
@@ -39,7 +41,7 @@ Friday we drove from Spokane to Salem, left at 6am and got in at 2pm because of 
 
 ![The IRONMAN event shirt printed with athletes' names, mine (Andrew Rich) in the center](/images/blog/five-races-name-shirt.jpg)
 
-Saturday morning was an 8-mile shakeout ride, my first real ride in longer than I want to say, and it went fine, because that kind of thing doesn't fully leave you. Back to Playtri to adjust the front disc, athlete briefing, bike checked into transition, back to the hotel to lay out my gear the way I've laid out gear for fifteen years. Early dinner, bed, alarm set for 3:30am.
+Saturday morning was an 8-mile shakeout ride, my first real ride in longer than I want to say, and it went fine, because that kind of thing doesn't fully leave you. Afterward, the front brake squealed loudly when I applied it, so I went back to Playtri. They fixed it, then I went to the athlete briefing, checked my bike into transition, and returned to the hotel to lay out my gear the way I've laid out gear for fifteen years. Early dinner, bed, alarm set for 3:30am.
 
 ![My bike racked in the transition area the day before the race](/images/blog/five-races-bike-transition.jpg)
 
@@ -55,12 +57,12 @@ At 5:38am, transition already open, I should have been prepping my gear. Instead
 
 ![The email I sent that morning, subject line "cannot proceed," telling the race I couldn't safely start](/images/blog/five-races-cannot-proceed-email.jpg)
 
-I took more of my medication and went back to sleep.
+I took an extra dose of medication—something I reserve for extreme circumstances—and went back to sleep.
 
 We got the bike back as soon as checkout opened at 12:30, packed up, and drove home. We'd planned to stay one more night for a celebratory dinner. Instead we left that afternoon and got back to Spokane a little after 9pm. I mostly avoided finishers on the way out, which would have been hard to be around, and saw exactly one car with race stickers on the whole drive, hours later and already back in Washington. The drive itself was long and uneventful. If I didn't hate crating my bike so much I'd have flown instead.
 
 ![The welcoming committee when we got home: our four cats](/images/blog/five-races-cats.jpg)
 
-I'm retiring from long-course triathlon. Not from the sport: I've got a local sprint race in September and I intend to do it. But 70.3 and up is done. Five consecutive DNFs and DNSes is a pattern. I don't see anything a sixth attempt would tell me that the last five haven't already.
+I'm retiring from long-course triathlon. Not from the sport: I've got a local sprint race in September and I intend to do it. But 70.3 and up is done. Five consecutive races I did not complete form a pattern. I don't see anything a sixth attempt would tell me that the last five haven't already.
 
-I don't have a clean way to end this. I have a therapy appointment in a few weeks that predates all of this and will probably help me sort out more of it than I can right now. What I know today is that Arizona 2023 broke something that two years and a good course couldn't fix, that the version of me who could talk himself into "I can still finish" on a Saturday night was not lying, exactly, and that the version who woke up Sunday morning was more honest. Both of those were me. I'd rather write that down plainly than pretend the second one wasn't real.
+I don't yet know whether Arizona broke something or simply exposed something that had been building for years. I don't need to solve that question before deciding what comes next. The long-course chapter is over. In September, I'll start a local sprint and see what remains when the distance is no longer the point.


### PR DESCRIPTION
## What

Editorial pass on the already-published **Five Races** post (`src/content/blog/2026-07-20-five-races.md`), applying Andrew's local revisions.

## Changes

- Replace the vague "look up the weather in Tempe" line with the actual Phoenix Sky Harbor readings (94/96/98°F, RH 17%→12%).
- Correct the race-count claims to be accurate: thirteen triathlon start lines, seven IRONMAN 70.3s, one full IRONMAN.
- Add the A2 Bikes SP1.1 detail and the pre-race brake-squeal fix at Playtri.
- Rework the closing into a less tidy, more honest ending.
- Tighten the description meta.

## Verification

- Voice check per `docs/VOICE.md`: clean (2 em-dashes, no banned vocab, no bold list lead-ins, no emphasis-italics).
- `npm run build`: passes, `/blog/five-races/` generates.
- All 9 referenced images present under `public/images/blog/`.
- markdownlint: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)