### PR TITLE
feat: add native share button to post pages

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -45,6 +45,9 @@ const back = backLinks[collection];
           Originally published on <a href={mediumUrl} rel="noopener noreferrer" target="_blank">Medium</a>.
         </p>
       )}
+      <button type="button" id="share-button" class="share-button" data-title={title} hidden>
+        Share
+      </button>
     </header>
 
     <div class="prose">
@@ -52,6 +55,49 @@ const back = backLinks[collection];
     </div>
   </article>
 </BaseLayout>
+
+<script>
+  function initShareButton(): void {
+    const button = document.getElementById('share-button') as HTMLButtonElement | null;
+    if (!button) return;
+
+    const canNativeShare = typeof navigator.share === 'function';
+    // Show the button whenever we have some way to share: native share sheet,
+    // or the clipboard fallback.
+    if (!canNativeShare && typeof navigator.clipboard?.writeText !== 'function') return;
+    button.hidden = false;
+
+    const label = button.textContent?.trim() ?? 'Share';
+
+    button.addEventListener('click', async () => {
+      const shareData = {
+        title: button.dataset.title ?? document.title,
+        url: window.location.href,
+      };
+
+      if (canNativeShare) {
+        try {
+          await navigator.share(shareData);
+          return;
+        } catch (err) {
+          // AbortError means the user cancelled the share sheet — do nothing.
+          if (err instanceof Error && err.name === 'AbortError') return;
+          // Otherwise fall through to the clipboard fallback below.
+        }
+      }
+
+      try {
+        await navigator.clipboard.writeText(shareData.url);
+        button.textContent = 'Link copied!';
+        setTimeout(() => { button.textContent = label; }, 2000);
+      } catch {
+        // Clipboard write failed (e.g. permissions) — leave the button as-is.
+      }
+    });
+  }
+
+  initShareButton();
+</script>
 
 <style>
   .post-header {
@@ -85,6 +131,24 @@ const back = backLinks[collection];
     margin-top: 0.75rem;
     font-size: 0.85rem;
     color: var(--color-muted);
+  }
+
+  .share-button {
+    display: inline-block;
+    margin-top: 1rem;
+    font-family: var(--font-sans);
+    font-size: 0.8rem;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    padding: 0.35em 0.8em;
+    color: var(--color-muted);
+    cursor: pointer;
+  }
+
+  .share-button:hover {
+    color: var(--color-accent);
+    border-color: var(--color-accent);
   }
 
   .prose { line-height: 1.8; }


### PR DESCRIPTION
## Summary
- Adds a share button to `PostLayout.astro` post pages that uses the Web Share API (`navigator.share`) to trigger the native share sheet on supported platforms (iOS Safari/PWA, Android Chrome).
- Falls back to copying the page URL to the clipboard when `navigator.share` isn't available, with a "Link copied!" confirmation on the button.
- Button is feature-detected client-side and stays hidden if neither native share nor clipboard write is supported (older/unsupported browsers).
- Styled consistently with the existing `.tag` pill treatment (surface background, muted text, border, accent color on hover).

## Design notes
- Per the issue's own guidance, the button lives on post pages (in the post header, near the back-link/tags/medium-note).
- Feature-detects `navigator.share` directly rather than gating on `display-mode: standalone` — the issue itself notes this as the preferred approach so the button also works in a regular mobile browser tab, not just installed-PWA context.
- Note: this repo does not yet have a PWA manifest/service worker, so the site currently isn't installable as a standalone PWA. The share button works regardless (any browser exposing `navigator.share`), but true "PWA" installability is a separate, unaddressed prerequisite if that's desired later.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified button markup, `data-title` attribute, and bundled/minified client script render correctly in built HTML output for a post page
- [x] Local pre-commit and pre-push review hooks passed (adversarial reviewer, codebase reviewer)

Closes #104