### PR TITLE
fix: clear pending share-button timeout to prevent stale label restoration

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -68,6 +68,7 @@ const back = backLinks[collection];
     button.hidden = false;
 
     const label = button.textContent?.trim() ?? 'Share';
+    let resetTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
     button.addEventListener('click', async () => {
       const shareData = {
@@ -88,8 +89,9 @@ const back = backLinks[collection];
 
       try {
         await navigator.clipboard.writeText(shareData.url);
+        clearTimeout(resetTimeoutId);
         button.textContent = 'Link copied!';
-        setTimeout(() => { button.textContent = label; }, 2000);
+        resetTimeoutId = setTimeout(() => { button.textContent = label; }, 2000);
       } catch {
         // Clipboard write failed (e.g. permissions) — leave the button as-is.
       }


### PR DESCRIPTION
## Summary
- Fixes a race condition where clicking the share button a second time during the 2-second "Link copied!" reset window would queue a second `setTimeout`, letting the first timeout later overwrite the label at an unexpected moment.
- The timeout handle is now stored in the `initShareButton` closure and cleared via `clearTimeout` before a new one is scheduled on each click.

## Test plan
- [x] `npm run build` completes cleanly with no errors
- [x] Verified the built/minified bundle contains the `clearTimeout` call
- [x] Local code-reviewer and adversarial-reviewer both pass (pre-commit and pre-push hooks)
- [x] Manual code read of the full click handler confirms correct per-button closure scoping (single share button per page)

Fixes #111

https://claude.ai/code/session_01BmuTHyHEJv26WZkyTWHZDp